### PR TITLE
Bugfix/windows filepaths cause false positive duplicate detection

### DIFF
--- a/src/core/spec-locator.ts
+++ b/src/core/spec-locator.ts
@@ -41,7 +41,7 @@ export class SpecLocator implements Disposable {
     specLocatorOptions: SpecLocatorOptions = {}
   ) {
     this.disposables.push(logger, fileHandler);
-    this.cwd = specLocatorOptions.cwd ?? process.cwd();
+    this.cwd = toPosixPath(specLocatorOptions.cwd ?? process.cwd());
     this.specLocatorOptions = { ...specLocatorOptions, cwd: this.cwd };
     this.refreshFiles();
   }
@@ -206,10 +206,11 @@ export class SpecLocator implements Disposable {
   }
 
   private async getAbsoluteFilesForGlobs(fileGlobs: string[]): Promise<string[]> {
-    return await this.fileHandler.resolveFileGlobs(fileGlobs, this.specLocatorOptions);
+    return (await this.fileHandler.resolveFileGlobs(fileGlobs, this.specLocatorOptions)).map(path => toPosixPath(path));
   }
 
   private addSuiteFileToCache(suite: string[], filePath: string) {
+    this.logger.debug(() => `Adding spec file to cache: ${filePath}`);
     let suiteKey = '';
 
     for (const suiteAncestor of suite) {

--- a/src/core/spec-locator.ts
+++ b/src/core/spec-locator.ts
@@ -51,23 +51,27 @@ export class SpecLocator implements Disposable {
   }
 
   public async refreshFiles(files?: string[]): Promise<void> {
-    files = files?.map(f => toPosixPath(f));
-    const filesDescriptionList = JSON.stringify(files ?? this.filePatterns);
+    const posixPaths = files?.map(f => toPosixPath(f));
+    const filesDescriptionList = JSON.stringify(posixPaths ?? this.filePatterns);
 
     this.logger.debug(
-      () => `Received request to refresh ${files ? files.length : 'all'} spec file(s): ` + `${filesDescriptionList}`
+      () =>
+        `Received request to refresh ${posixPaths ? posixPaths.length : 'all'} spec file(s): ` +
+        `${filesDescriptionList}`
     );
     const deferredRefreshCompletion = new DeferredPromise();
     const futureRefreshCompletion = deferredRefreshCompletion.promise();
 
     const doRefresh = async () => {
-      this.logger.debug(() => `Refreshing ${files ? files.length : 'all'} spec file(s): ` + `${filesDescriptionList}`);
-      this.logger.trace(() => `List of file(s) to refresh: ${JSON.stringify(files)}`);
+      this.logger.debug(
+        () => `Refreshing ${posixPaths ? posixPaths.length : 'all'} spec file(s): ` + `${filesDescriptionList}`
+      );
+      this.logger.trace(() => `List of file(s) to refresh: ${JSON.stringify(posixPaths)}`);
 
       const reloadStartTime = Date.now();
-      this.purgeFiles(files ?? undefined);
+      this.purgeFiles(posixPaths ?? undefined);
 
-      const filesToRefresh = files ?? (await this.getAbsoluteFilesForGlobs(this.filePatterns));
+      const filesToRefresh = posixPaths ?? (await this.getAbsoluteFilesForGlobs(this.filePatterns));
       let loadedFileCount: number = 0;
 
       for (const file of filesToRefresh) {
@@ -83,7 +87,7 @@ export class SpecLocator implements Disposable {
 
       this.logger.debug(
         () =>
-          `Refreshed ${loadedFileCount} spec ${files ? 'files' : 'globs'} ` +
+          `Refreshed ${loadedFileCount} spec ${posixPaths ? 'files' : 'globs'} ` +
           `in ${reloadSecs.toFixed(2)} secs: ${filesDescriptionList}`
       );
     };
@@ -107,7 +111,8 @@ export class SpecLocator implements Disposable {
   }
 
   public removeFiles(absoluteFilePaths: string[]) {
-    this.purgeFiles(absoluteFilePaths);
+    const posixFilePaths = absoluteFilePaths.map(path => toPosixPath(path));
+    this.purgeFiles(posixFilePaths);
   }
 
   private purgeFiles(absoluteFilePaths?: string[]) {

--- a/src/core/spec-locator.ts
+++ b/src/core/spec-locator.ts
@@ -51,6 +51,7 @@ export class SpecLocator implements Disposable {
   }
 
   public async refreshFiles(files?: string[]): Promise<void> {
+    files = files?.map(f => toPosixPath(f));
     const filesDescriptionList = JSON.stringify(files ?? this.filePatterns);
 
     this.logger.debug(

--- a/test/core/spec-locator.test.ts
+++ b/test/core/spec-locator.test.ts
@@ -1,0 +1,42 @@
+import { mock, MockProxy } from 'jest-mock-extended';
+import { SpecLocator } from '../../src/core/spec-locator';
+import { TestFileParser, TestSuiteFileInfo } from '../../src/core/test-file-parser';
+import { FileHandler } from '../../src/util/file-handler';
+import { Logger } from '../../src/util/logging/logger';
+
+describe('SpecLocator', () => {
+  const testFilePatterns: string[] = [];
+  let mockTestFileParser: MockProxy<TestFileParser>;
+  let mockFileHandler: MockProxy<FileHandler>;
+  let mockLogger: MockProxy<Logger>;
+
+  let specLocator: SpecLocator;
+
+  beforeEach(() => {
+    mockTestFileParser = mock<TestFileParser>();
+    mockTestFileParser.parseFileText.mockReturnValue(<TestSuiteFileInfo>{
+      Suite: [{ description: 'SuiteName', lineNumber: 1 }],
+      Test: [{ description: 'TestName', lineNumber: 2 }]
+    });
+
+    mockFileHandler = mock<FileHandler>();
+    mockFileHandler.resolveFileGlobs.mockReturnValue(Promise.resolve(['C:\\windows\\test\\path\\xyz.test.ts']));
+
+    mockLogger = mock<Logger>();
+
+    specLocator = new SpecLocator(testFilePatterns, mockTestFileParser, mockFileHandler, mockLogger);
+  });
+
+  it('should build spec locator', () => {
+    expect(specLocator).not.toBeUndefined();
+    expect(specLocator).not.toBeNull();
+  });
+
+  describe('getSpecLocation method', () => {
+    it('should return unix file paths', () => {
+      const specLocations = specLocator.getSpecLocation(['SuiteName'], 'TestName');
+
+      expect(specLocations.every(loc => !loc.file.includes('\\'))).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
### **What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Bug Fix for #4 

### **What is the current behavior? (You can also link to an open issue here)**

- SpecLocator uses whatever filepaths are given to it by its consumers.

### **What is the new behavior (if this is a feature change)**

- SpecLocator converts input to unix style paths before placing it in the cache to make sure filepath styles in the cache are never mixed.

### **What might this PR break?**

- Testing on my Windows machine nothing seems to be negatively impacted by using unix paths in the SpecLocator cache. It looks like other areas of the code also use `toPosixPath` so I expect Windows/VSC handle them as expected. I don't do any VSC extension development but it seems to work correctly and refresh my tests the correct way. :shrug:

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

Hopefully my tests are adequate/appropriate, still learning to write them; hence the desire to have this extension work 😃 