### PR TITLE
Fix test discovery and duplicate detection issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,28 +8,34 @@ assignees: ''
 ---
 
 **Describe the Bug**
-A clear and concise description of what the bug is.
 
-**To Reproduce:**
-Steps to reproduce the behavior:
+- A clear and concise description of what the bug is.
+
+**Steps to Reproduce the Behavior**
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected Behavior:**
-A clear and concise description of what you expected to happen.
+**Describe the Expected Behavior**
 
-**Debug Logs:**
-With the `karmaTestExplorer.logLevel` set to `debug`, please capture and attach the logs from the `Karma Test Explorer` Output panel.
+- A clear and concise description of what you expected to happen.
 
-**Screenshots:**
-If applicable, add screenshots to help explain the issue you are having.
+**Debug Logs**
 
-**Please Provide the Following Information:**
- - OS: [e.g. macOS]
- - Environment [e.g. DevContainer Guest OS and version]
- - Version [e.g. 22]
+- With the `karmaTestExplorer.logLevel` set to `debug`, please capture and attach the logs from the `Karma Test Explorer` Output panel.
 
-**Additional Context:**
-Add any other context about the problem here.
+**Screenshots**
+
+- If applicable, add screenshots to help explain the issue you are having.
+
+**Please Provide the Following Information**
+ 
+ - OS: (e.g. macOS)
+ - Environment (e.g. DevContainer Guest OS and version)
+ - Version (e.g. 22)
+
+**Additional Context**
+
+- Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,20 +1,24 @@
 ---
-Name: Feature request
-About: Suggest an idea for this project
-Title: ''
-Labels: ''
-Assignees: ''
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe:**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+**Is Your Feature Request related to a Problem? Please Describe**
 
-**Describe the solution you'd like:**
-A clear and concise description of what you want to happen.
+- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe alternatives you've considered:**
-A clear and concise description of any alternative solutions or features you've considered.
+**Describe the Solution You'd Like**
 
-**Additional context:**
-Add any other context or screenshots about the feature request here.
+- A clear and concise description of what you want to happen.
+
+**Describe Alternatives You've Considered**
+
+- A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional Context**
+
+- Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
@@ -1,0 +1,35 @@
+---
+name: Bug fix
+about: Create a pull request to fix a bug
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**What kind of Bug Fix Change does this PR Introduce?**
+
+- [ ] Non-breaking change (which fixes a bug)
+- [ ] Breaking change (which fixes a bug)
+
+**What is the Current Behavior? (You can also Link to an Open Issue Here)**
+
+- A clear and concise description of what the current behavior is.
+- Related issue: #(issue_number)
+
+**What is the New Behavior (If this is a Feature Change)**
+
+- A clear and concise description of what the new behavior is and how it differs from the current behavior.
+
+**What might this PR Break?**
+
+- A clear and concise description of what other functionality or behavior is most likely to be impacted by the changes in this PR.
+
+**Please Check if the PR Fulfills these Requirements**
+
+- [ ] Tests for the changes have been added
+- [ ] Docs have been added / updated
+
+**Other Information**
+
+- Add any other information about this pull request here.

--- a/.github/PULL_REQUEST_TEMPLATE/new_feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new_feature.md
@@ -1,0 +1,35 @@
+---
+name: New feature
+about: Create a pull request to add a new feature or enhancement
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**What kind of Feature or Enhancement Change does this PR Introduce?**
+
+- [ ] Non-breaking change (which adds a new feature or functionality)
+- [ ] Breaking change (which adds a new feature but causes existing functionality to not work as expected)
+
+**What is the Current Behavior? (You can also Link to an Open Issue Here)**
+
+- A clear and concise description of what the current behavior is.
+- Related issue: #(issue_number)
+
+**What is the New Behavior**
+
+- A clear and concise description of what the new behavior is and how it differs from the current behavior.
+
+**What might this PR Break?**
+
+- A clear and concise description of what other functionality or behavior is most likely to be impacted by the changes in this PR.
+
+**Please Check if the PR Fulfills these Requirements**
+
+- [ ] Tests for the changes have been added
+- [ ] Docs have been added / updated
+
+**Other Information**
+
+- Add any other information about this pull request here.

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,9 +5,10 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ master, beta ]
+    branches: [ master ]
   pull_request:
-    branches: [ master, beta ]
+    branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   build:
@@ -16,7 +17,7 @@ jobs:
       max-parallel: 3
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     runs-on: ${{ matrix.os }}
@@ -34,3 +35,8 @@ jobs:
     - run: npm run build
     - run: npm test
     - run: npm run package
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: packaged-vsix
+        path: ./*.vsix

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
 	"[typescript]": {
 		"editor.defaultFormatter": "dbaeumer.vscode-eslint",
 	},
+	"typescript.tsdk": "node_modules/typescript/lib",
 	"eslint.format.enable": true,
 
 	"files.exclude": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,25 @@ The format of this changelog is loosely based on [Keep a Changelog](https://keep
 <details>
   <summary>Releases</summary>
 
-  - [0.2.0 - Oct 2021](#020---oct-2021)
-  - [0.1.0 - Sep 2021](#010---sep-2021)
+  - [0.2.1 - Oct 24, 2021](#021---oct-24-2021)
+  - [0.2.0 - Oct 13, 2021](#020---oct-13-2021)
+  - [0.1.0 - Sep 28, 2021](#010---sep-28-2021)
 </details>
 
 
 ---
-## [0.2.0] - Oct 2021
+## [0.2.1] - Oct 24, 2021
+
+### Changed
+
+- Test duplication is only now reported for tests but no longer reported for test suites because test suites are simply containers for tests, so that duplicated test suites are themselves not an indication that actual tests have also been duplicated
+
+### Fixed
+- Fixed an issue where test duplicate detection was producing false-positives on Windows (thanks [@nwash57](https://github.com/nwash57)!)
+- Fixed an issue where some tests may not always be discovered on Windows
+
+---
+## [0.2.0] - Oct 13, 2021
 
 ### Added
 
@@ -37,7 +49,8 @@ The format of this changelog is loosely based on [Keep a Changelog](https://keep
 - Fixed [an issue](https://github.com/lucono/karma-test-explorer/issues/2) (#2) where spaces in the user's home directory or the extension installation path caused the extension to fail for Windows users
 - Fixed issue where line numbers shown in warning messages for detected duplicate test definitions were off by one line
 
-## [0.1.0] - Sep 2021
+---
+## [0.1.0] - Sep 28, 2021
 
 ### Added
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,6 @@ For linting and building the code, and running unit tests, you can use the follo
 
 <a href="#contents"><img align="right" height="24" src="docs/img/back-to-top.png"></a>
 
----
 ## See Also
 
 - [Readme](https://github.com/lucono/karma-test-explorer/blob/master/README.md#karma-test-explorer-for-visual-studio-code)

--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ To quickly get started:
 
 - Ensure the required dependencies are installed - Chrome browser on the computer or container, and the project dependencies (such as Karma, Angular, Jasmine, Mocha, etc)
 - Install the Karma Test Explorer [extension](https://marketplace.visualstudio.com/items?itemName=lucono.karma-test-explorer)
-- If the project root path is not same as the VS Code workspace path, specify its path using the `karmaTestExplorer.projectRootPath` setting
+- If the project root path is not same as the VS Code workspace root, specify its path using the `karmaTestExplorer.projectRootPath` setting
 - If the `karma.conf.js` file is not at the project root folder, specify its path using the `karmaTestExplorer.karmaConfFilePath` setting
 - Specify your project's test files using the `karmaTestExplorer.testFiles` setting
-- Select the Karma Test Explorer prompt to apply the updated settings and wait a moment while it refreshes
+- Apply the updated settings and wait a moment while it refreshes, or simply restart VS Code
 - When done, you should see your tests in the Test View, and code lenses above each test in the editor, either of which can be used to run and debug the tests
 
 ---
-_Also use the many other [extension options](https://github.com/lucono/karma-test-explorer/blob/master/docs/guide.md#configuration) to further customize it to the needs of your project and team, and if you run into any issues with setup or usage, please see the more detailed [Documentation](https://github.com/lucono/karma-test-explorer/blob/master/docs/documentation.md#documentation---karma-test-explorer)._
+Also explore the many other [extension settings](https://github.com/lucono/karma-test-explorer/blob/master/docs/documentation.md#configuration) to further customize it to the needs of your project and team, and if you run into any issues with setup or usage, please see the more detailed [Documentation](https://github.com/lucono/karma-test-explorer/blob/master/docs/documentation.md#documentation---karma-test-explorer) for help.
 
 ---
 
@@ -72,7 +72,7 @@ For a more detailed guide on how to setup Karma Test Explorer to work with your 
 
 ## Why this Extension
 
-The Karma Test Explorer extension was initially created out of [need for additional features](https://github.com/Raagh/angular-karma_test-explorer/issues?q=is%3Aissue+author%3Alucono) from the [Angular/Karma Test Explorer](https://github.com/Raagh/angular-karma_test-explorer) extension at a time when that project seemed not to be accepting contributions anymore, and is a major rewrite aimed at facilitating various significant enhancements and new features (such as some of those in the initial release [changelog](https://github.com/lucono/karma-test-explorer/blob/master/CHANGELOG.md#010---sep-2021)). 
+The Karma Test Explorer extension was initially created out of [need for additional features](https://github.com/Raagh/angular-karma_test-explorer/issues?q=is%3Aissue+author%3Alucono) from the [Angular/Karma Test Explorer](https://github.com/Raagh/angular-karma_test-explorer) extension at a time when that project seemed not to be accepting contributions anymore, and is a major rewrite aimed at facilitating various significant enhancements and new features (such as some of those in the initial release [changelog](https://github.com/lucono/karma-test-explorer/blob/master/CHANGELOG.md#010---sep-28-2021)). 
 
 This extension's core focus is on better and robust support for:
 
@@ -91,7 +91,6 @@ Special thanks to the [author](https://github.com/Raagh) and contributors of the
 
 If you encounter any problems using Karma Test Explorer, would like to request a feature, or have any questions, please open an issue [here](https://github.com/lucono/karma-test-explorer/issues/new).
 
----
 ## See Also
 
 - [Documentation](https://github.com/lucono/karma-test-explorer/blob/master/docs/documentation.md#documentation---karma-test-explorer)

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -2,7 +2,7 @@
 
 ## Contents
 
-- [Getting Started](#getting-started)
+- [Setup](#setup)
 - [Project Types](#project-types)
 - [Test Frameworks](#test-frameworks)
 - [Configuration](#configuration)
@@ -13,33 +13,40 @@
 - [Known Issues and Limitations](#known-issues-and-limitations)
 - [See Also](#see-also)
 
-## Getting Started
+---
 
-### Install Prerequisites
+## Setup
 
-Prerequisite | Description
--------------|------------
-Test&nbsp;Browser | Karma Test Explorer requires a browser for running tests, which by default is the Chrome browser, though you can provide a custom launcher which uses a different browser. Whichever browser is used must be installed on the computer or container where VS Code will be running your project's tests
-Test&nbsp;Frameworks | The various frameworks required for your project's tests must be installed. This can include for instance, some of Angular, Karma, Jasmine, Mocha, Karma-Jasmine, Karma-Mocha, etc, all of which will usually be defined as Dev dependencies in your project's package.json file, so that simply running `npm install` would ensure they are all installed
-Karma&nbsp;Test&nbsp;Explorer | The Karma Test Explorer [extension](https://marketplace.visualstudio.com/items?itemName=lucono.karma-test-explorer) must be installed and enabled in VS Code. If developing and testing your project in a container, then the extension's installation mode in VS Code should be in the remote workspace
+### 1. Install Prerequisites
 
-### Configure Extension
+|Prerequisite | Description|
+|:-------------|------------|
+|Test&nbsp;Browser | Karma Test Explorer requires a browser for running tests, which by default is the Chrome browser, though you can provide a custom launcher which uses a different browser. Whichever browser is used must be installed on the computer or container where VS Code will be running your project's tests|
+|Test&nbsp;Frameworks | The various frameworks required for your project's tests must be installed. This can include for instance, some of Angular, Karma, Jasmine, Mocha, Karma-Jasmine, Karma-Mocha, etc, all of which will usually be defined as Dev dependencies in your project's package.json file, so that simply running `npm install` would ensure they are all installed|
+|Karma&nbsp;Test&nbsp;Explorer | The Karma Test Explorer [extension](https://marketplace.visualstudio.com/items?itemName=lucono.karma-test-explorer) must be installed and enabled in VS Code. If developing and testing your project in a container, then the extension's installation mode in VS Code should be in the remote workspace|
 
-Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Only&nbsp;Required | Config&nbsp;Setting
--------|---------------|----------------
-Specify project root path relative to the workspace folder | If the root path of the project is not the same as the VS Code workspace root folder | `karmaTestExplorer.projectRootPath`
-Specify `karma.conf.js` file path relative to the project root folder | If the `karma.conf.js` file has a different filename, or is not located in the project root folder | `karmaTestExplorer.karmaConfFilePath`
-Specify project [test files](#specifying-test-files) | Always recommended, for better performance | `karmaTestExplorer.testFiles`
-Provide any other relevant [settings](#configuration) | Optional but recommended - use the various other Karma Test Explorer configuration [options](#configuration) to further customize it to the needs of your project and team| [Config Settings](#configuration)
+### 2. Configure Extension
 
-When done updating the settings, select the Karma Test Explorer prompt to __Apply Settings__ and wait a moment while it refreshes. You can also reload VS Code to apply the changes if you don't see the prompt.
+|Description&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | When&nbsp;Required | Config&nbsp;Setting
+|:-------|---------------|----------------
+|Specify project root path relative to the workspace folder | If the root path of the project is not the same as the VS Code workspace root folder | `karmaTestExplorer.projectRootPath`
+|Specify `karma.conf.js` file path relative to the project root folder | If the `karma.conf.js` file has a different filename, or is not located in the project root folder | `karmaTestExplorer.karmaConfFilePath`
+|Specify project [test files](#specifying-test-files) | Always recommended, for better performance | `karmaTestExplorer.testFiles`
+|Provide any other relevant [settings](#configuration) | Optional but recommended - use the various other Karma Test Explorer configuration [options](#configuration) to further customize it to the needs of your project and team| See [all settings](#configuration)
+
+### 3. Run Your Tests
+
+When done configuring the extension, select the Karma Test Explorer prompt to __Apply Settings__ and wait a moment while it refreshes. You can also simply reload VS Code to apply the changes if you don't see the prompt.
+
+After Karma Test Explorer is done refreshing with the updated settings, your tests should show up in the Test View, as well as code lenses above each test in the code editor, either of which can be used to run and debug the tests.
+  
+---
+
+Note that Karma Test Explorer will briefly display updates (using available space if any) on the VS Code status bar, showing the current status of test operations. You can click on the status bar message to display additional options or show the extension log.
 
 <a href="#contents"><img align="right" height="24" src="img/back-to-top.png"></a>
 
-### Run Your Tests
-
-- After Karma Test Explorer is done refreshing with the updated settings, your tests should show up in the Test View, as well as code lenses above each test in the code editor, either of which can be used to run and debug the tests
-- Note that Karma Test Explorer will briefly display updates (using available space if any) on the VS Code status bar, showing the current status of the test operations. You can click on the status bar message to display additional options or show the extension log.
+---
 
 ## Project Types
 
@@ -51,6 +58,8 @@ By default, any project with an `angular.json` or `.angular-cli.json` file in th
 Projects without an `angular.json` or `.angular-cli.json` file in the project root are treated as plain Karma projects. Use the various [extension options](#configuration) where necessary to customize Karma Test Explorer's behavior to the specific needs of your project and team.
 
 <a href="#contents"><img align="right" height="24" src="img/back-to-top.png"></a>
+
+---
 
 ## Test Frameworks
 
@@ -65,11 +74,11 @@ If your project uses the Jasmine test framework and it is not automatically dete
 If your project uses the Mocha test framework and it - or the right Mocha interface style - is not automatically detected by Karma Test Explorer, use the `karmaTestExplorer.testFramework` config option to specify which Mocha testing interface style (BDD or TDD) is used by your tests.
 
 ---
-_Note that watch mode is currently not supported for the Mocha test framework._
-
----
+Note that watch mode is currently not supported for the Mocha test framework.
 
 <a href="#contents"><img align="right" height="24" src="img/back-to-top.png"></a>
+
+---
 
 ## Configuration
 
@@ -108,6 +117,8 @@ Setting                                       | Description
 
 <a href="#contents"><img align="right" height="24" src="img/back-to-top.png"></a>
 
+---
+
 ## Specifying Test Files
 
 By default, Karma Test Explorer searches for test files in every path under the project root directory (excluding `node_modules` directories). However, by explicitly specifying the location of your test files via the `karmaTestExplorer.testFiles` setting, you can reduce the amount of file scanning that's required to find your tests by limiting it to only the folders and files that actually contain the tests, which can significantly speed up discovery of your tests and improve the overall performance of your testing with the Karma Test Explorer.
@@ -141,6 +152,8 @@ For example:
 
 <a href="#contents"><img align="right" height="24" src="img/back-to-top.png"></a>
 
+---
+
 ## Specifying a Test Framework
 
 By default, when no test framework is specified (ie, the `karmaTestExplorer.testFramework` config option is not set), Karma Test Explorer will try to auto-detect the test framework that is used by your project by looking at its `karma.conf.js` file. If it detects the Mocha framework, it will by default assume the BDD style for the project. If your project uses Mocha with the TDD style instead, or if your project's test framework is not correctly detected for any other reason, you can explicitly specify the right framework by setting the `karmaTestExplorer.testFramework` config option, whicn can have one of the following values:
@@ -155,11 +168,13 @@ Most times however, you will not need to set this config option at all as Karma 
 
 <a href="#contents"><img align="right" height="24" src="img/back-to-top.png"></a>
 
+---
+
 ## Testing in a Development Container
 
 With VS Code's Development Container feature, you can develop and run your project's Karma tests inside a container, using browsers installed in that container. However, launching Chrome and other Chromium browsers in a container environment often requires additional browser flags and other adjustments. Therefore, to fully support DevContainer-based setups and workflows, Karma Test Explorer provides a number of options to help make development and testing smoother and more seamless in those scenarios.
 
-### Using `karmaTestExplorer.containerMode`
+### Use `karmaTestExplorer.containerMode`
 
 By default, Karma Test Explorer will automatically detect whether you are testing in a container environment, in which case it will activate `containerMode` which makes all necessary customizations required for smoother container-based development and testing. You can also manually enable this mode by setting the `karmaTestExplorer.containerMode` config setting to `enabled`. Because its default value when not set is `auto`, it should mostly not be necessary to manually set this option at all, unless in a situation where you are running in a container environment and find that Karma Test Explorer is not able to automatically detect it.
 
@@ -217,7 +232,11 @@ For more elaborate or highly custom project or environment setups that require a
 
 <a href="#contents"><img align="right" height="24" src="img/back-to-top.png"></a>
 
+---
+
 ## Output Panels
+
+Karma Test Explorer adds the output channels described below to the Output panel of VS Code. Some or all of these channels can be disabled by setting their corresponding `logLevel` config option to `disable` in cases where this option is available.
 
 Name | Description
 -----|-------------
@@ -225,6 +244,8 @@ Karma&nbsp;Test&nbsp;Explorer | This output panel shows the logs of the Karma Te
 Karma&nbsp;Server | This output panel shows the Karma server log. The `karmaTestExplorer.karmaLogLevel` can be used to set the level of logging detail desired from the Karma server.
 
 <a href="#contents"><img align="right" height="24" src="img/back-to-top.png"></a>
+
+---
 
 ## Known Issues and Limitations
 
@@ -244,6 +265,7 @@ Karma&nbsp;Server | This output panel shows the Karma server log. The `karmaTest
 <a href="#contents"><img align="right" height="24" src="img/back-to-top.png"></a>
 
 ---
+
 ## See Also
 
 - [Readme](https://github.com/lucono/karma-test-explorer/blob/master/README.md#karma-test-explorer-for-visual-studio-code)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "karma-test-explorer",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "karma-test-explorer",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "bluebird": "^3.7.2",
@@ -58,7 +58,7 @@
         "prettier-plugin-organize-imports": "^2.3.4",
         "ts-jest": "^27.0.5",
         "typescript": "^4.4.3",
-        "vsce": "^1.100.1"
+        "vsce": "^1.100.2"
       },
       "engines": {
         "vscode": "^1.60.0"
@@ -7218,9 +7218,9 @@
       }
     },
     "node_modules/vsce": {
-      "version": "1.100.1",
-      "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.100.1.tgz",
-      "integrity": "sha512-1VjLyse5g6e2eQ6jUpslu7IDq44velwF8Jy8s7ePdwGNuG8EzfmaOfVyig3ZSMJ0l8DiJmZllx5bRAB4RMdnHg==",
+      "version": "1.100.2",
+      "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.100.2.tgz",
+      "integrity": "sha512-eDeubJNc0iav6mbTESZ90E9WcSzqAAl/lunb4KbNjRrz9tf+657i1mKhnWUyvK7Y4D8kN5NBD2FXD4FFMZj7ig==",
       "dev": true,
       "dependencies": {
         "azure-devops-node-api": "^11.0.1",
@@ -7247,7 +7247,7 @@
         "yazl": "^2.2.2"
       },
       "bin": {
-        "vsce": "out/vsce"
+        "vsce": "vsce"
       },
       "engines": {
         "node": ">= 10"
@@ -13041,9 +13041,9 @@
       "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w="
     },
     "vsce": {
-      "version": "1.100.1",
-      "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.100.1.tgz",
-      "integrity": "sha512-1VjLyse5g6e2eQ6jUpslu7IDq44velwF8Jy8s7ePdwGNuG8EzfmaOfVyig3ZSMJ0l8DiJmZllx5bRAB4RMdnHg==",
+      "version": "1.100.2",
+      "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.100.2.tgz",
+      "integrity": "sha512-eDeubJNc0iav6mbTESZ90E9WcSzqAAl/lunb4KbNjRrz9tf+657i1mKhnWUyvK7Y4D8kN5NBD2FXD4FFMZj7ig==",
       "dev": true,
       "requires": {
         "azure-devops-node-api": "^11.0.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "icon": "docs/img/extension-icon-128.png",
   "author": "Lucas Ononiwu",
   "publisher": "lucono",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "preview": true,
   "license": "MIT",
   "homepage": "https://github.com/lucono/karma-test-explorer",
@@ -19,9 +19,6 @@
   "categories": [
     "Testing"
   ],
-  "jest": {
-    "testEnvironment": "node"
-  },
   "keywords": [
     "karma",
     "angular",
@@ -99,7 +96,7 @@
     "prettier-plugin-organize-imports": "^2.3.4",
     "ts-jest": "^27.0.5",
     "typescript": "^4.4.3",
-    "vsce": "^1.100.1"
+    "vsce": "^1.100.2"
   },
   "engines": {
     "vscode": "^1.60.0"
@@ -393,10 +390,5 @@
         }
       }
     }
-  },
-  "__metadata": {
-    "id": "eea8111e-ea45-4aa2-8d60-48efb3edc54e",
-    "publisherDisplayName": "Lucas Ononiwu",
-    "publisherId": "26f17aec-afc6-4165-b153-1c670baba559"
   }
 }

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -9,7 +9,6 @@ import {
   EventEmitter,
   FileChangeType,
   FileSystemWatcher,
-  Uri,
   workspace,
   WorkspaceFolder
 } from 'vscode';
@@ -51,6 +50,7 @@ import { Disposable } from './util/disposable/disposable';
 import { Disposer } from './util/disposable/disposer';
 import { DeferredPromise } from './util/future/deferred-promise';
 import { Execution } from './util/future/execution';
+import { LogLevel, LogLevelName } from './util/logging/log-level';
 import { SimpleLogger } from './util/logging/simple-logger';
 import { getCircularReferenceReplacer, normalizePath } from './util/utils';
 
@@ -98,11 +98,6 @@ export class Adapter implements TestAdapter, Disposable {
       commands.registerCommand(`${ExtensionCommands.Reload}`, () => this.reload()),
       commands.registerCommand(`${ExtensionCommands.ExecuteFunction}`, (fn: () => void) => fn())
     );
-  }
-
-  private async reinit() {
-    await Disposer.dispose(this.initDisposables);
-    this.init();
   }
 
   private init() {
@@ -159,6 +154,11 @@ export class Adapter implements TestAdapter, Disposable {
       testResolver
     );
     this.initDisposables.push(this.testManager);
+  }
+
+  private async reinit() {
+    await Disposer.dispose(this.initDisposables);
+    this.init();
   }
 
   public async run(testIds: string[], isDebug: boolean = false): Promise<void> {
@@ -411,14 +411,15 @@ export class Adapter implements TestAdapter, Disposable {
 
   private createConfig(): ExtensionConfig {
     const config: ConfigStore = workspace.getConfiguration(EXTENSION_CONFIG_PREFIX, this.workspaceFolder.uri);
-    const configLogger = new SimpleLogger(this.logger, ExtensionConfig.name);
+    const logLevel = LogLevel[config.get<string>(ConfigSetting.LogLevel)!.toUpperCase() as LogLevelName];
+    const configLogger = new SimpleLogger(this.extensionOutputChannelLog, ExtensionConfig.name, logLevel);
     return new ExtensionConfig(config, this.workspaceFolder.uri.path, configLogger);
   }
 
   private createFileWatchers(): Disposable[] {
     this.logger.debug(() => 'Creating file watchers for monitored files');
-
     const reloadTriggerFiles = [...this.config.reloadOnChangedFiles];
+
     if (this.config.reloadOnKarmaConfigChange) {
       reloadTriggerFiles.push(this.config.userKarmaConfFilePath);
     }
@@ -428,17 +429,16 @@ export class Adapter implements TestAdapter, Disposable {
 
     const reloadTriggerFilesWatchers = this.registerFileHandler(
       reloadTriggerFiles,
-      debounce(WATCHED_FILE_CHANGE_BATCH_DELAY, fileUri => {
-        const filePath = fileUri.fsPath;
+      debounce(WATCHED_FILE_CHANGE_BATCH_DELAY, filePath => {
         this.logger.info(() => `Requesting adapter reset - monitored file changed: ${filePath}`);
         this.reset();
       })
     );
 
     this.logger.debug(() => 'Creating file watchers for test file changes');
+    const testFileGlobs = this.config.testFiles;
 
-    const reloadTestFilesWatchers = this.registerFileHandler(this.config.testFiles, async (fileUri, changeType) => {
-      const changedTestFile = fileUri.fsPath;
+    const reloadTestFilesWatchers = this.registerFileHandler(testFileGlobs, async (changedTestFile, changeType) => {
       if (!this.specLocator?.isSpecFile(changedTestFile)) {
         this.logger.warn(() => `Expected changed file to be spec file but it is not: ${changedTestFile}`);
         return;
@@ -466,11 +466,11 @@ export class Adapter implements TestAdapter, Disposable {
 
   private registerFileHandler(
     filePatterns: readonly string[],
-    handler: (fileUri: Uri, changeType: FileChangeType) => void
+    handler: (filePath: string, changeType: FileChangeType) => void
   ): FileSystemWatcher[] {
     const fileWatchers: FileSystemWatcher[] = [];
 
-    this.logger.debug(() => `Registering file handler for files: ${filePatterns}`);
+    this.logger.debug(() => `Registering file handler for files: ${JSON.stringify(filePatterns, null, 2)}`);
 
     for (const fileOrPattern of filePatterns) {
       const absoluteFileOrPattern = normalizePath(resolve(this.config.projectRootPath, fileOrPattern));
@@ -484,9 +484,9 @@ export class Adapter implements TestAdapter, Disposable {
       );
 
       this.disposables.push(
-        fileWatcher.onDidChange(fileUri => handler(fileUri, FileChangeType.Changed)),
-        fileWatcher.onDidCreate(fileUri => handler(fileUri, FileChangeType.Created)),
-        fileWatcher.onDidDelete(fileUri => handler(fileUri, FileChangeType.Deleted))
+        fileWatcher.onDidChange(fileUri => handler(normalizePath(fileUri.fsPath), FileChangeType.Changed)),
+        fileWatcher.onDidCreate(fileUri => handler(normalizePath(fileUri.fsPath), FileChangeType.Created)),
+        fileWatcher.onDidDelete(fileUri => handler(normalizePath(fileUri.fsPath), FileChangeType.Deleted))
       );
     }
     return fileWatchers;

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -52,7 +52,7 @@ import { Disposer } from './util/disposable/disposer';
 import { DeferredPromise } from './util/future/deferred-promise';
 import { Execution } from './util/future/execution';
 import { SimpleLogger } from './util/logging/simple-logger';
-import { getCircularReferenceReplacer, toPosixPath } from './util/utils';
+import { getCircularReferenceReplacer, normalizePath } from './util/utils';
 
 export class Adapter implements TestAdapter, Disposable {
   private specLocator?: SpecLocator;
@@ -473,7 +473,7 @@ export class Adapter implements TestAdapter, Disposable {
     this.logger.debug(() => `Registering file handler for files: ${filePatterns}`);
 
     for (const fileOrPattern of filePatterns) {
-      const absoluteFileOrPattern = toPosixPath(resolve(this.config.projectRootPath, fileOrPattern));
+      const absoluteFileOrPattern = normalizePath(resolve(this.config.projectRootPath, fileOrPattern));
       const fileWatcher = workspace.createFileSystemWatcher(absoluteFileOrPattern);
       fileWatchers.push(fileWatcher);
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,18 +5,20 @@ export const EXTENSION_NAME = 'Karma Test Explorer';
 export const EXTENSION_CONFIG_PREFIX = 'karmaTestExplorer';
 export const EXTENSION_OUTPUT_CHANNEL_NAME = EXTENSION_NAME;
 export const DEFAULT_LOG_LEVEL = LogLevel.DEBUG;
-export const DEBUG_SESSION_START_TIMEOUT = 15_000;
-export const STATUS_BAR_MESASGE_MAX_DURATION = 300_000;
-export const CONFIG_FILE_CHANGE_BATCH_DELAY = 3000;
+export const DEBUG_SESSION_START_TIMEOUT = 1000 * 15;
+export const STATUS_BAR_MESASGE_MAX_DURATION = 1000 * 60 * 5;
+export const CONFIG_FILE_CHANGE_BATCH_DELAY = 1000 * 3;
 export const WATCHED_FILE_CHANGE_BATCH_DELAY = 2500;
 
 // Karma constants
 export const KARMA_SERVER_OUTPUT_CHANNEL_NAME = 'Karma Server';
 export const KARMA_CUSTOM_LAUNCHER_BROWSER_NAME = 'KarmaTestExplorer_CustomLauncher';
 export const KARMA_BROWSER_CONTAINER_NO_SANDBOX_FLAG = '--no-sandbox';
-export const KARMA_SOCKET_PING_INTERVAL = 24 * 60 * 60 * 1000;
-export const KARMA_SOCKET_PING_TIMEOUT = 24 * 60 * 60 * 1000;
+export const KARMA_TEST_RUN_ID_FLAG = '--testRunId';
+export const KARMA_SOCKET_PING_INTERVAL = 1000 * 60 * 60 * 24;
+export const KARMA_SOCKET_PING_TIMEOUT = 1000 * 60 * 60 * 24;
 export const KARMA_READY_DEFAULT_TIMEOUT = 1000 * 60 * 15;
+export const KARMA_TEST_EVENT_INTERVAL_TIMEOUT = 1000 * 60;
 
 // Others
 export const ALWAYS_EXCLUDED_TEST_FILE_GLOBS = ['**/node_modules/**/*'];

--- a/src/core/main-factory.ts
+++ b/src/core/main-factory.ts
@@ -287,7 +287,7 @@ export class MainFactory {
         this.config.projectRootPath,
         this.config.testsBasePath,
         testResolver,
-        this.createLogger(`${KarmaTestEventProcessor.name}_Ambient`)
+        this.createLogger(`${KarmaAutoWatchTestEventProcessor.name}:${KarmaTestEventProcessor.name}`)
       );
 
       watchModeTestEventProcessor = new KarmaAutoWatchTestEventProcessor(

--- a/src/core/spec-locator.ts
+++ b/src/core/spec-locator.ts
@@ -41,7 +41,7 @@ export class SpecLocator implements Disposable {
     specLocatorOptions: SpecLocatorOptions = {}
   ) {
     this.disposables.push(logger, fileHandler);
-    this.cwd = specLocatorOptions.cwd ?? process.cwd();
+    this.cwd = toPosixPath(specLocatorOptions.cwd ?? process.cwd());
     this.specLocatorOptions = { ...specLocatorOptions, cwd: this.cwd };
     this.refreshFiles();
   }
@@ -206,10 +206,11 @@ export class SpecLocator implements Disposable {
   }
 
   private async getAbsoluteFilesForGlobs(fileGlobs: string[]): Promise<string[]> {
-    return await this.fileHandler.resolveFileGlobs(fileGlobs, this.specLocatorOptions);
+    return (await this.fileHandler.resolveFileGlobs(fileGlobs, this.specLocatorOptions)).map(path => toPosixPath(path));
   }
 
   private addSuiteFileToCache(suite: string[], filePath: string) {
+    this.logger.debug(() => `Adding spec file to cache: ${filePath}`);
     let suiteKey = '';
 
     for (const suiteAncestor of suite) {

--- a/src/core/spec-locator.ts
+++ b/src/core/spec-locator.ts
@@ -51,23 +51,27 @@ export class SpecLocator implements Disposable {
   }
 
   public async refreshFiles(files?: string[]): Promise<void> {
-    files = files?.map(f => toPosixPath(f));
-    const filesDescriptionList = JSON.stringify(files ?? this.filePatterns);
+    const posixPaths = files?.map(f => toPosixPath(f));
+    const filesDescriptionList = JSON.stringify(posixPaths ?? this.filePatterns);
 
     this.logger.debug(
-      () => `Received request to refresh ${files ? files.length : 'all'} spec file(s): ` + `${filesDescriptionList}`
+      () =>
+        `Received request to refresh ${posixPaths ? posixPaths.length : 'all'} spec file(s): ` +
+        `${filesDescriptionList}`
     );
     const deferredRefreshCompletion = new DeferredPromise();
     const futureRefreshCompletion = deferredRefreshCompletion.promise();
 
     const doRefresh = async () => {
-      this.logger.debug(() => `Refreshing ${files ? files.length : 'all'} spec file(s): ` + `${filesDescriptionList}`);
-      this.logger.trace(() => `List of file(s) to refresh: ${JSON.stringify(files)}`);
+      this.logger.debug(
+        () => `Refreshing ${posixPaths ? posixPaths.length : 'all'} spec file(s): ` + `${filesDescriptionList}`
+      );
+      this.logger.trace(() => `List of file(s) to refresh: ${JSON.stringify(posixPaths)}`);
 
       const reloadStartTime = Date.now();
-      this.purgeFiles(files ?? undefined);
+      this.purgeFiles(posixPaths ?? undefined);
 
-      const filesToRefresh = files ?? (await this.getAbsoluteFilesForGlobs(this.filePatterns));
+      const filesToRefresh = posixPaths ?? (await this.getAbsoluteFilesForGlobs(this.filePatterns));
       let loadedFileCount: number = 0;
 
       for (const file of filesToRefresh) {
@@ -83,7 +87,7 @@ export class SpecLocator implements Disposable {
 
       this.logger.debug(
         () =>
-          `Refreshed ${loadedFileCount} spec ${files ? 'files' : 'globs'} ` +
+          `Refreshed ${loadedFileCount} spec ${posixPaths ? 'files' : 'globs'} ` +
           `in ${reloadSecs.toFixed(2)} secs: ${filesDescriptionList}`
       );
     };
@@ -107,7 +111,8 @@ export class SpecLocator implements Disposable {
   }
 
   public removeFiles(absoluteFilePaths: string[]) {
-    this.purgeFiles(absoluteFilePaths);
+    const posixFilePaths = absoluteFilePaths.map(path => toPosixPath(path));
+    this.purgeFiles(posixFilePaths);
   }
 
   private purgeFiles(absoluteFilePaths?: string[]) {

--- a/src/core/spec-locator.ts
+++ b/src/core/spec-locator.ts
@@ -51,6 +51,7 @@ export class SpecLocator implements Disposable {
   }
 
   public async refreshFiles(files?: string[]): Promise<void> {
+    files = files?.map(f => toPosixPath(f));
     const filesDescriptionList = JSON.stringify(files ?? this.filePatterns);
 
     this.logger.debug(

--- a/src/core/test-suite-organizer.ts
+++ b/src/core/test-suite-organizer.ts
@@ -69,7 +69,9 @@ export class TestSuiteOrganizer implements Disposable {
         return;
       }
       if (!test.file) {
-        this.logger.warn(() => `Got test with unknown file: ${JSON.stringify(test)}`);
+        this.logger.warn(() => `Got test with unknown file - Test Id is: ${test.id}`);
+        this.logger.trace(() => `Test with unknown file: ${JSON.stringify(test)}`);
+
         fileLessSpecsSuite.push(test);
         return;
       }

--- a/src/frameworks/angular/angular-test-server-executor.ts
+++ b/src/frameworks/angular/angular-test-server-executor.ts
@@ -78,10 +78,11 @@ export class AngularTestServerExecutor implements TestServerExecutor {
     } else if (isAngularInstalledGlobally) {
       command = 'ng';
     } else {
-      const errorMessage = '@angular/cli does not seem to be installed. Please install it and try again.';
-      this.logger.error(() => errorMessage);
-      deferredServerExecution.fail(errorMessage);
-      return deferredServerExecution.execution();
+      throw new Error(
+        `@angular/cli does not seem to be installed - ` +
+          `You may need to run 'npm install' in your project. ` +
+          `Please install it and try again.`
+      );
     }
 
     processArguments = [

--- a/src/frameworks/karma/runner/karma-command-line-test-run-executor.ts
+++ b/src/frameworks/karma/runner/karma-command-line-test-run-executor.ts
@@ -50,7 +50,11 @@ export class KarmaCommandLineTestRunExecutor implements TestRunExecutor {
     } else if (isKarmaInstalledGlobally) {
       command = 'karma';
     } else {
-      throw new Error('Karma does not seem to be installed. Please install it and try again.');
+      throw new Error(
+        `Karma does not seem to be installed - ` +
+          `You may need to run 'npm install' in your project. ` +
+          `Please install it and try again.`
+      );
     }
 
     const escapedClientArgs: string[] = clientArgs.map(arg => this.shellEscape(arg));

--- a/src/frameworks/karma/runner/karma-event.ts
+++ b/src/frameworks/karma/runner/karma-event.ts
@@ -3,10 +3,11 @@ import { TestRunStatus } from './test-run-status';
 
 export interface KarmaEvent {
   readonly name: KarmaEventName;
-  readonly port?: number;
-  readonly results?: LightSpecCompleteResponse;
+  readonly runId?: string;
   readonly runStatus?: TestRunStatus;
   readonly runInfo?: Record<string, unknown>;
+  readonly port?: number;
+  readonly results?: LightSpecCompleteResponse;
   readonly browser?: BrowserInfo;
   readonly browsers?: BrowserInfo[];
   readonly info?: Record<string, unknown>;

--- a/src/frameworks/karma/runner/karma-http-test-run-executor.ts
+++ b/src/frameworks/karma/runner/karma-http-test-run-executor.ts
@@ -60,11 +60,6 @@ export class KarmaHttpTestRunExecutor implements TestRunExecutor {
 
     request.on('close', () => {
       this.logger.debug(() => 'Karma http request closed');
-
-      // FIXME: Request sometimes is done while server is still
-      // running the requested tests so that deferredTestRunExecution
-      // is ended prematurely and subsequent test results are not
-      // collected or reported in the extension
       deferredTestRunExecution.end();
     });
 

--- a/src/frameworks/karma/runner/spec-response-to-test-suite-info-mapper.ts
+++ b/src/frameworks/karma/runner/spec-response-to-test-suite-info-mapper.ts
@@ -92,25 +92,6 @@ export class SpecResponseToTestSuiteInfoMapper {
     const suiteFullName = suitePath.join(' ');
     const suiteId = `${suiteFile}:${suiteFullName}`;
 
-    const hasDuplicates = allMatchingSuiteLocations.length > 1;
-    let message: string | undefined;
-
-    if (hasDuplicates) {
-      let duplicateSuiteCounter = 0;
-
-      const duplicateSuiteFiles = allMatchingSuiteLocations
-        .sort((loc1, loc2) => (loc1.file === suiteFile ? -1 : loc2.file === suiteFile ? 1 : 0))
-        .map(location => `${++duplicateSuiteCounter}. ${location.file}:${location.line + 1}`)
-        .join('\n');
-
-      message =
-        `"${suiteFullName}" \n\n` +
-        '---------- \n\n' +
-        'The above test suite has duplicate definitions in the following files ' +
-        'in your project which could lead to conflicting test results: \n\n' +
-        `${duplicateSuiteFiles}`;
-    }
-
     const suiteNode: TestSuiteInfo = {
       type: TestType.Suite,
       id: suiteId,
@@ -120,8 +101,7 @@ export class SpecResponseToTestSuiteInfoMapper {
       children: [],
       testCount: 0,
       file: suiteLocation?.file,
-      line: suiteLocation?.line,
-      message
+      line: suiteLocation?.line
     };
     return suiteNode;
   }

--- a/src/frameworks/karma/server/karma-command-line-test-server-executor.ts
+++ b/src/frameworks/karma/server/karma-command-line-test-server-executor.ts
@@ -76,7 +76,11 @@ export class KarmaCommandLineTestServerExecutor implements TestServerExecutor {
     } else if (isKarmaInstalledGlobally) {
       command = 'karma';
     } else {
-      throw new Error('Karma does not seem to be installed. Please install it and try again.');
+      throw new Error(
+        `Karma does not seem to be installed - ` +
+          `You may need to run 'npm install' in your project. ` +
+          `Please install it and try again.`
+      );
     }
 
     processArguments = [...processArguments, 'start', this.baseKarmaConfigFile, '--no-single-run'];

--- a/src/util/file-handler.ts
+++ b/src/util/file-handler.ts
@@ -5,6 +5,7 @@ import { Disposable } from './disposable/disposable';
 import { Disposer } from './disposable/disposer';
 import { DeferredPromise } from './future/deferred-promise';
 import { Logger } from './logging/logger';
+import { normalizePath } from './utils';
 
 const DEFAULT_GLOB_OPTIONS: globby.GlobbyOptions = {
   unique: true,
@@ -67,7 +68,7 @@ export class FileHandler implements Disposable {
 
   public async resolveFileGlobs(filePatterns: string[], globOptions: globby.GlobbyOptions = {}): Promise<string[]> {
     const searchOptions = { ...DEFAULT_GLOB_OPTIONS, ...this.fileHandlerOptions, ...globOptions };
-    const files = await globby(filePatterns, searchOptions);
+    const files = (await globby(filePatterns, searchOptions)).map(file => normalizePath(file));
 
     this.logger.debug(() => `Resolved ${files.length} file(s) from file patterns: ${JSON.stringify(filePatterns)}`);
 

--- a/src/util/future/deferred-execution.ts
+++ b/src/util/future/deferred-execution.ts
@@ -26,6 +26,8 @@ export class DeferredExecution<S = void, T = void> {
   public end(value: T) {
     if (this.executionInstance.isStarted()) {
       this.deferredExecutionEnd.fulfill(value);
+    } else {
+      throw new Error('Attempt to end execution before starting it');
     }
   }
 

--- a/src/util/future/execution.ts
+++ b/src/util/future/execution.ts
@@ -1,13 +1,13 @@
 import RichPromise from 'bluebird';
 
-export class Execution<S = void, T = void> {
-  public constructor(private readonly futureStart: RichPromise<S>, private readonly futureEnd: RichPromise<T>) {}
+export class Execution<S = void, E = void> {
+  public constructor(private readonly futureStart: RichPromise<S>, private readonly futureEnd: RichPromise<E>) {}
 
   public started(): RichPromise<S> {
     return this.futureStart;
   }
 
-  public ended(): RichPromise<T> {
+  public ended(): RichPromise<E> {
     return this.futureEnd;
   }
 

--- a/src/util/utils.ts
+++ b/src/util/utils.ts
@@ -29,7 +29,7 @@ export const escapeForRegExp = (stringValue: string) => stringValue.replace(/[.*
 export const normalizePath = (filePath: string): string => {
   return process.platform === 'win32'
     ? filePath
-        .replace(/^([a-zA-Z]):/, driveLetter => driveLetter.toUpperCase())
+        .replace(/^[\/]?([A-Za-z]:)/, (_, drive) => drive.toUpperCase())
         .split(path.sep)
         .join(path.posix.sep)
     : filePath;

--- a/src/util/utils.ts
+++ b/src/util/utils.ts
@@ -26,7 +26,14 @@ export const stripJsComments = (content: string): string => {
 // From MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
 export const escapeForRegExp = (stringValue: string) => stringValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
-export const toPosixPath = (filePath: string) => filePath.split(path.sep).join(path.posix.sep);
+export const normalizePath = (filePath: string): string => {
+  return process.platform === 'win32'
+    ? filePath
+        .replace(/^([a-zA-Z]):/, driveLetter => driveLetter.toUpperCase())
+        .split(path.sep)
+        .join(path.posix.sep)
+    : filePath;
+};
 
 // From MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Cyclic_object_value
 export const getCircularReferenceReplacer = () => {

--- a/test/core/config/extension-config.test.ts
+++ b/test/core/config/extension-config.test.ts
@@ -18,6 +18,10 @@ describe('ExtensionConfig', () => {
     mockConfigValues = new Map();
     mockConfigDefaults = new Map();
 
+    mockConfigValues.set(ConfigSetting.TestFiles, []);
+    mockConfigValues.set(ConfigSetting.ExcludeFiles, []);
+    mockConfigValues.set(ConfigSetting.ReloadOnChangedFiles, []);
+
     mockConfigStore = {
       has: mockConfigValues.has,
       get: key => (mockConfigValues.has(key) ? mockConfigValues.get(key) : ''),

--- a/test/core/spec-locator.test.ts
+++ b/test/core/spec-locator.test.ts
@@ -1,0 +1,42 @@
+import { mock, MockProxy } from 'jest-mock-extended';
+import { SpecLocator } from '../../src/core/spec-locator';
+import { TestFileParser, TestSuiteFileInfo } from '../../src/core/test-file-parser';
+import { FileHandler } from '../../src/util/file-handler';
+import { Logger } from '../../src/util/logging/logger';
+
+describe('SpecLocator', () => {
+  const testFilePatterns: string[] = [];
+  let mockTestFileParser: MockProxy<TestFileParser>;
+  let mockFileHandler: MockProxy<FileHandler>;
+  let mockLogger: MockProxy<Logger>;
+
+  let specLocator: SpecLocator;
+
+  beforeEach(() => {
+    mockTestFileParser = mock<TestFileParser>();
+    mockTestFileParser.parseFileText.mockReturnValue(<TestSuiteFileInfo>{
+      Suite: [{ description: 'SuiteName', lineNumber: 1 }],
+      Test: [{ description: 'TestName', lineNumber: 2 }]
+    });
+
+    mockFileHandler = mock<FileHandler>();
+    mockFileHandler.resolveFileGlobs.mockReturnValue(Promise.resolve(['C:\\windows\\test\\path\\xyz.test.ts']));
+
+    mockLogger = mock<Logger>();
+
+    specLocator = new SpecLocator(testFilePatterns, mockTestFileParser, mockFileHandler, mockLogger);
+  });
+
+  it('should build spec locator', () => {
+    expect(specLocator).not.toBeUndefined();
+    expect(specLocator).not.toBeNull();
+  });
+
+  describe('getSpecLocation method', () => {
+    it('should return unix file paths', () => {
+      const specLocations = specLocator.getSpecLocation(['SuiteName'], 'TestName');
+
+      expect(specLocations.every(loc => !loc.file.includes('\\'))).toBeTruthy();
+    });
+  });
+});

--- a/test/core/spec-locator.test.ts
+++ b/test/core/spec-locator.test.ts
@@ -91,6 +91,19 @@ describe('SpecLocator', () => {
           await specLocator.refreshFiles(['xyz.test.ts']);
           expect(specLocator['specFilesBySuite'].get('SuiteName')).toEqual(expect.arrayContaining(['xyz.test.ts']));
         });
+
+        it('should clear and reload cache using the file globs if no files specified', async () => {
+          const modifiedGlobFiles = ['file1.test.ts', 'file2.test.ts', 'file3.test.ts'];
+
+          expect(specLocator['specFilesBySuite'].get('SuiteName')).not.toEqual(
+            expect.arrayContaining(modifiedGlobFiles)
+          );
+
+          mockResolvedGlobFiles = modifiedGlobFiles;
+          await specLocator.refreshFiles();
+
+          expect(specLocator['specFilesBySuite'].get('SuiteName')).toEqual(expect.arrayContaining(modifiedGlobFiles));
+        });
       });
 
       describe('removeFiles method', () => {

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -6,8 +6,8 @@ export type Writeable<T> = { -readonly [P in keyof T]: T[P] };
 
 export const asUnixStylePath = <T extends string | undefined>(path: T): T => {
   const isWindowsOs = process.platform === 'win32';
-  const osAgnosticPath = isWindowsOs ? path?.replace(/^[a-zA-Z]:/, '').replace(/\\/g, '/') : path;
-  return osAgnosticPath as T;
+  const unixStylePath = isWindowsOs ? path?.replace(/^[a-zA-Z]:/, '').replace(/\\/g, '/') : path;
+  return unixStylePath as T;
 };
 
 export const withUnixStyleSeparator = (filePath: string) => filePath.split(pathSeparator).join(posix.sep);

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -1,3 +1,4 @@
+import { posix, sep as pathSeparator } from 'path';
 import { AnyTestInfo } from '../src/core/base/test-infos';
 import { ExtensionConfig } from '../src/core/config/extension-config';
 
@@ -8,6 +9,8 @@ export const asUnixStylePath = <T extends string | undefined>(path: T): T => {
   const osAgnosticPath = isWindowsOs ? path?.replace(/^[a-zA-Z]:/, '').replace(/\\/g, '/') : path;
   return osAgnosticPath as T;
 };
+
+export const withUnixStyleSeparator = (filePath: string) => filePath.split(pathSeparator).join(posix.sep);
 
 export const asExtensionConfigWithUnixStylePaths = (extensionConfig: ExtensionConfig): ExtensionConfig => {
   const config = extensionConfig as Writeable<ExtensionConfig>;


### PR DESCRIPTION
- Normalizes all paths received by the `SpecLocator` class to use unix-style path separators, which work for both windows and unix-style systems, including Mac and Linux
- Fixes #4 