### PR TITLE
Fixes and updates for v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format of this changelog is loosely based on [Keep a Changelog](https://keep
 <details>
   <summary>Releases</summary>
 
+  - [0.7.1 - Jul 23, 2022](#071---jul-23-2022)
   - [0.7.0 - Jul 17, 2022](#070---jul-17-2022)
   - [0.6.1 - Apr 13, 2022](#061---apr-13-2022)
   - [0.6.0 - Apr 6, 2022](#060---apr-6-2022)
@@ -18,6 +19,13 @@ The format of this changelog is loosely based on [Keep a Changelog](https://keep
   - [0.1.0 - Sep 28, 2021](#010---sep-28-2021)
 </details>
 
+
+---
+## [0.7.1] - Jul 23, 2022
+
+### Added
+
+- Support for parameterized tests and template string test descriptions, as well as some support for computed string test descriptions. This support builds on the new AST-based Test Definition Provider added in the v0.7.0 release, and requires the `karmaTestExplorer.testParsingMethod` setting to be `ast` (the current default when this setting is not configured)
 
 ---
 ## [0.7.0] - Jul 17, 2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format of this changelog is loosely based on [Keep a Changelog](https://keep
 <details>
   <summary>Releases</summary>
 
-  - [0.7.1 - Jul 23, 2022](#071---jul-23-2022)
+  - [0.7.1 - Jul 24, 2022](#071---jul-24-2022)
   - [0.7.0 - Jul 17, 2022](#070---jul-17-2022)
   - [0.6.1 - Apr 13, 2022](#061---apr-13-2022)
   - [0.6.0 - Apr 6, 2022](#060---apr-6-2022)
@@ -21,7 +21,7 @@ The format of this changelog is loosely based on [Keep a Changelog](https://keep
 
 
 ---
-## [0.7.1] - Jul 23, 2022
+## [0.7.1] - Jul 24, 2022
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ The format of this changelog is loosely based on [Keep a Changelog](https://keep
 
 ### Fixed
 
-- Addresses long-standing issue where parameterized tests are not recognized, as well as tests with template or computed string descriptions. This support is provided by the new AST-based Test Definition Provider added in v0.7.0 and therefore requires the `karmaTestExplorer.testParsingMethod` setting to be `ast` (which is the current default when this setting is not configured)
+- Addresses a long-standing issue where parameterized tests are unmapped, as well as tests with template or computed string descriptions. This support is provided by the new AST-based Test Definition Provider added in v0.7.0 and therefore requires the `karmaTestExplorer.testParsingMethod` setting to be `ast` (which is the current default when this setting is not configured)
 
 ---
 ## [0.7.0] - Jul 17, 2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,9 @@ The format of this changelog is loosely based on [Keep a Changelog](https://keep
 ---
 ## [0.7.1] - Jul 23, 2022
 
-### Added
+### Fixed
 
-- Support for parameterized tests and template string test descriptions, as well as some support for computed string test descriptions. This support builds on the new AST-based Test Definition Provider added in the v0.7.0 release, and requires the `karmaTestExplorer.testParsingMethod` setting to be `ast` (the current default when this setting is not configured)
+- Addresses long-standing issue where parameterized tests are not recognized, as well as tests with template or computed string descriptions. This support is provided by the new AST-based Test Definition Provider added in v0.7.0 and therefore requires the `karmaTestExplorer.testParsingMethod` setting to be `ast` (which is the current default when this setting is not configured)
 
 ---
 ## [0.7.0] - Jul 17, 2022

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
-
-[![Open in Development Container](https://img.shields.io/static/v1?label=VS%20Code&message=Open%20in%20Container&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/lucono/karma-test-explorer)
 [![Installs](https://vsmarketplacebadge.apphb.com/installs-short/lucono.karma-test-explorer.svg)](https://marketplace.visualstudio.com/items?itemName=lucono.karma-test-explorer)
 [![Rating](https://vsmarketplacebadge.apphb.com/rating-short/lucono.karma-test-explorer.svg)](https://marketplace.visualstudio.com/items?itemName=lucono.karma-test-explorer)
 [![Build and Test](https://github.com/lucono/karma-test-explorer/actions/workflows/node.js.yml/badge.svg)](https://github.com/lucono/karma-test-explorer/actions/workflows/node.js.yml)
 
 # Karma Test Explorer (for Angular, Jasmine, and Mocha)
 
-This extension runs your Karma or Angular tests in Visual Studio Code using the [Test Explorer UI](https://marketplace.visualstudio.com/items?itemName=hbenl.vscode-test-explorer), and supports the Jasmine and Mocha test frameworks. It is based on [Angular/Karma Test Explorer](https://github.com/Raagh/angular-karma_test-explorer), with various significant [enhancements](#why-this-extension).
+This extension runs your Karma or Angular tests in Visual Studio Code using the [Test Explorer UI](https://marketplace.visualstudio.com/items?itemName=hbenl.vscode-test-explorer), and supports the Jasmine and Mocha test frameworks.
 
 ![Karma Test Explorer screenshot](./docs/img/sidebar.png)
 
@@ -19,7 +17,7 @@ Please take a minute to rate this extension in the [marketplace](https://marketp
 
 ## Why this Extension
 
-Karma Test Explorer is based on the [Angular/Karma Test Explorer](https://github.com/Raagh/angular-karma_test-explorer) extension and is a major rewrite aimed at facilitating various significant enhancements and new features, and robust support for:
+Karma Test Explorer is a major rewrite of the deprecated [Angular/Karma Test Explorer](https://github.com/Raagh/angular-karma_test-explorer) extension, and is aimed at facilitating various significant enhancements and new features, with a focus on robust support for:
 
 - Large projects with thousands of tests
 - Remote development sceanarios with [Dev Containers](https://code.visualstudio.com/docs/remote/containers)
@@ -27,26 +25,24 @@ Karma Test Explorer is based on the [Angular/Karma Test Explorer](https://github
 - Smooth user experience to "just work" without any or much configuration
 - Reliability, usability, and productivity
 
----
-
 ## Features
 
-- Angular and Karma project support
-- Jasmine and Mocha framework support
-- Multi-project and monorepo support
-- Active update of test pass-fail statuses
-- Duplicate test detection and flagging
-- Filter view to remove noise from disabled tests
-- [See more](./docs/documentation.md#features)
+- Rich visual test browsing, execution, and debugging
+- Angular, Karma, Jasmine, and Mocha support
+- Multi-project / monorepo / multi-root workspace support
+- Live update of pass-fail test statuses
+- Filter out noise from disabled tests or show only focused tests
+- Duplicate test detection and reporting
+- [Much more](./docs/documentation.md#features)
 
 ## Quick Start
 
-Karma Test Explorer uses reasonable defaults, and in many cases will work out-of-the-box without any configuration. To quickly get started:
+In many cases, testing should work without any manual configuration. To quickly get started:
 
 - Ensure Chrome browser and the project dependencies are installed
 - Install the Karma Test Explorer [extension](https://marketplace.visualstudio.com/items?itemName=lucono.karma-test-explorer) and wait a moment while it initializes
 - When done, your tests should be displayed in the Testing side bar
-- Use the many [extension settings](./docs/documentation.md#extension-settings) to customize it to the needs of your project
+- Use the many [extension settings](./docs/documentation.md#extension-settings) to customize it to any other needs of your project
 - If you run into any issues, see [extension setup](./docs/documentation.md#extension-setup) for more detailed setup instructions
 
 ## Documentation
@@ -55,11 +51,8 @@ For a more detailed guide on setting up, customizing, and fully leveraging all t
 
 ## Acknowledgement
 
-Special thanks to the [author](https://github.com/Raagh) and contributors of the [Angular/Karma Test Explorer](https://github.com/Raagh/angular-karma_test-explorer) extension on which Karma Test Explorer is based.
+Special thanks to the authors of [Angular/Karma Test Explorer](https://github.com/Raagh/angular-karma_test-explorer) on which Karma Test Explorer is based.
 
 ## See Also
 
-- [Documentation](./docs/documentation.md#documentation---karma-test-explorer)
-- [Contributing](./CONTRIBUTING.md#contributing---karma-test-explorer)
-- [Changelog](./CHANGELOG.md#changelog)
-- [Report an issue](./docs/documentation.md#reporting-issues)
+[Documentation](./docs/documentation.md#documentation---karma-test-explorer) &nbsp;|&nbsp; [Contributing](./CONTRIBUTING.md#contributing---karma-test-explorer) &nbsp;|&nbsp; [Changelog](./CHANGELOG.md#changelog) &nbsp;|&nbsp; [Report an issue](./docs/documentation.md#reporting-issues)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
+[![Build and Test](https://github.com/lucono/karma-test-explorer/actions/workflows/node.js.yml/badge.svg)](https://github.com/lucono/karma-test-explorer/actions/workflows/node.js.yml)
 [![Installs](https://vsmarketplacebadge.apphb.com/installs-short/lucono.karma-test-explorer.svg)](https://marketplace.visualstudio.com/items?itemName=lucono.karma-test-explorer)
 [![Rating](https://vsmarketplacebadge.apphb.com/rating-short/lucono.karma-test-explorer.svg)](https://marketplace.visualstudio.com/items?itemName=lucono.karma-test-explorer)
-[![Build and Test](https://github.com/lucono/karma-test-explorer/actions/workflows/node.js.yml/badge.svg)](https://github.com/lucono/karma-test-explorer/actions/workflows/node.js.yml)
 
 # Karma Test Explorer (for Angular, Jasmine, and Mocha)
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -41,13 +41,13 @@ Duplicated tests in your project are also detected and convniently flagged for a
 
 ### Core Features
 
-- Angular and Karma project support
-- Jasmine and Mocha test framework support
-- Multi project, monorepo and multi-root workspace support
-- Watch mode support with auto pass / fail test status update
+- Rich visual test browsing, execution, and debugging
+- Angular, Karma, Jasmine, and Mocha support
+- Multi-project / monorepo / multi-root workspace support
+- Live update of pass-fail test statuses
+- Filter out noise from disabled tests or show only focused tests
 - Duplicate test detection and reporting
 - Non-Headless testing / use visible browser window
-- Show only focused tests or exclude disabled tests from the test view
 - Group and run tests by folder or by test suite
 - Support for [Dev Containers](https://code.visualstudio.com/docs/remote/containers)
 - Specify or override environment variables for Karma
@@ -248,11 +248,11 @@ Most times however, you will not need to set this config option at all as Karma 
 
 Karma Test Explorer supports simultaneous multi-project testing for various multi-project setups and scenarios, including:
 
-Project Type | Description
+Multi-Project Setup | Description
 -------------|------------
-VS Code multi-root workspaces | For a multi-root workspace that is open in VS Code, all Karma and Angular projects in each root of the multi-root workspace will be available to load for testing
-Multi-project Angular workspaces | For each Angular project that is configured or automatically discovered by Karma Test Explorer in a VS Code workspace, all its sub-projects will be available to load for testing
-Monorepos and Embedded projects | For a monorepo with different projects in various sub-folders, or a single project with embedded projects located in paths under the main project folder, the various projects can be configured for simultaneous testing in a single VS Code workspace using the `karmaTestExplorer.projects` extension setting, which allows for specifying the path to each project and optionally also providing some project-specific settings for each
+VS Code multi-root workspace | For a multi-root workspace that is open in VS Code, all Karma and Angular projects in each root of the multi-root workspace will be available to load for testing
+Multi-project Angular workspace | For each Angular workspace that is configured or automatically discovered by Karma Test Explorer in a VS Code workspace, all its sub-projects will be available to load for testing
+Monorepo or Embedded project | For a monorepo with different projects in various sub-folders, or a single project with embedded projects located in paths under the main project folder, the various projects can be configured for simultaneous testing in a single VS Code workspace using the `karmaTestExplorer.projects` extension setting, which allows for specifying the path to each project and optionally also providing some project-specific settings for each
 
 In any scenario, whenever multiple Karma or Angular projects are available for testing, a folder button will be available on the Test view toolbar which can be used for selecting and loading any number of those projects for simultaneous testing in the UI. The folder button is not available when there is only a single project configured or detected for testing in the current VS Code workspace.
 
@@ -368,16 +368,6 @@ Karma&nbsp;Server | This output panel shows the Karma server log. The `karmaTest
 
 - Karma Test Explorer works best with the Test Explorer UI, and may not work properly if the `testExplorer.useNativeTesting` config setting is set to `true` to disable the Test Explorer UI in favor of VS Code's native testing UI
 - Watch mode is not yet supported for the Mocha test framework
-- Test descriptions that are computed are currently not supported. Test descriptions must be plain string literals in order to be available in the Test view side bar. For example:
-  ```ts
-  // Supported
-  it('supports plain literal test descriptions', ...
-  it(`supports plain literal test descriptions`, ...
-
-  // Not supported
-  it('does not support computed ' + someValue + ' test descriptions', ...
-  it(`does not support computed ${someValue} test descriptions`, ...
-  ```
 
 <a href="#contents"><img align="right" height="24" src="img/back-to-top.png"></a>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "karma-test-explorer",
-	"version": "0.7.0",
+	"version": "0.7.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "karma-test-explorer",
-			"version": "0.7.0",
+			"version": "0.7.1",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/parser": "^7.18.8",
@@ -59,7 +59,7 @@
 				"simple-get": "^3.1.1",
 				"ts-jest": "^27.1.3",
 				"typescript": "^4.6.2",
-				"vsce": "^2.9.2"
+				"vsce": "^2.10.0"
 			},
 			"engines": {
 				"vscode": "^1.63.0"
@@ -7439,9 +7439,9 @@
 			}
 		},
 		"node_modules/vsce": {
-			"version": "2.9.2",
-			"resolved": "https://registry.npmjs.org/vsce/-/vsce-2.9.2.tgz",
-			"integrity": "sha512-xyLqL4U82BilUX1t6Ym2opQEa2tLGWYjbgB7+ETeNVXlIJz5sWBJjQJSYJVFOKJSpiOtQclolu88cj7oY6vvPQ==",
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/vsce/-/vsce-2.10.0.tgz",
+			"integrity": "sha512-b+wB3XMapEi368g64klSM6uylllZdNutseqbNY+tUoHYSy6g2NwnlWuAGKDQTYc0IqfDUjUFRQBpPgA89Q+Fyw==",
 			"dev": true,
 			"dependencies": {
 				"azure-devops-node-api": "^11.0.1",
@@ -13415,9 +13415,9 @@
 			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
 		},
 		"vsce": {
-			"version": "2.9.2",
-			"resolved": "https://registry.npmjs.org/vsce/-/vsce-2.9.2.tgz",
-			"integrity": "sha512-xyLqL4U82BilUX1t6Ym2opQEa2tLGWYjbgB7+ETeNVXlIJz5sWBJjQJSYJVFOKJSpiOtQclolu88cj7oY6vvPQ==",
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/vsce/-/vsce-2.10.0.tgz",
+			"integrity": "sha512-b+wB3XMapEi368g64klSM6uylllZdNutseqbNY+tUoHYSy6g2NwnlWuAGKDQTYc0IqfDUjUFRQBpPgA89Q+Fyw==",
 			"dev": true,
 			"requires": {
 				"azure-devops-node-api": "^11.0.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"icon": "docs/img/extension-icon-128.png",
 	"author": "Lucas Ononiwu",
 	"publisher": "lucono",
-	"version": "0.7.0",
+	"version": "0.7.1",
 	"license": "MIT",
 	"homepage": "https://github.com/lucono/karma-test-explorer",
 	"repository": {
@@ -95,7 +95,7 @@
 		"prettier-plugin-organize-imports": "^2.3.4",
 		"ts-jest": "^27.1.3",
 		"typescript": "^4.6.2",
-		"vsce": "^2.9.2",
+		"vsce": "^2.10.0",
 		"simple-get": "^3.1.1"
 	},
 	"engines": {

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -29,7 +29,7 @@ import { LogLevel } from './util/logging/log-level';
 import { SimpleLogger } from './util/logging/simple-logger';
 import { PortAcquisitionClient } from './util/port/port-acquisition-client';
 import { PortAcquisitionManager } from './util/port/port-acquisition-manager';
-import { getCircularReferenceReplacer } from './util/utils';
+import { getJsonCircularReferenceReplacer } from './util/utils';
 
 export class Adapter implements TestAdapter, Disposable {
   private readonly outputChannelLog: OutputChannelLog;
@@ -124,7 +124,7 @@ export class Adapter implements TestAdapter, Disposable {
     this.logger.debug(
       () =>
         `Re/creating test explorer with extension configuration: ` +
-        `${JSON.stringify(this.config, getCircularReferenceReplacer(), 2)}`
+        `${JSON.stringify(this.config, getJsonCircularReferenceReplacer(), 2)}`
     );
 
     this.logger.debug(() => 'Creating main factory');

--- a/src/core/base/test-definition-provider.ts
+++ b/src/core/base/test-definition-provider.ts
@@ -4,7 +4,7 @@ import { TestDefinitionInfo } from '../test-locator';
 export interface TestDefinitionProvider extends Disposable {
   getTestDefinitions(suite: readonly string[], test: string): TestDefinitionInfo[];
 
-  addFileContent(file: string, testContent: string): void;
+  addFileContent(fileText: string, filePath: string): void;
 
   removeFileContents(files: readonly string[]): void;
 

--- a/src/core/base/test-definition.ts
+++ b/src/core/base/test-definition.ts
@@ -8,7 +8,6 @@ export enum TestDefinitionState {
 
 export interface TestDefinition {
   readonly type: TestType;
-  readonly description: string;
   readonly file: string;
   readonly line: number;
   readonly state: TestDefinitionState;

--- a/src/core/karma-test-explorer.ts
+++ b/src/core/karma-test-explorer.ts
@@ -137,12 +137,12 @@ export class KarmaTestExplorer implements Disposable {
         if (debuggerPort) {
           this.logger.debug(
             () =>
-              `Starting debug session '${debuggerConfigName}' ` +
+              `Starting debug session configuration '${debuggerConfigName}' ` +
               'with requested --> available debug port: ' +
               `${this.config.debuggerConfig.port ?? '<none>'} --> ${debuggerPort}`
           );
         } else {
-          this.logger.debug(() => `Starting debug session '${debuggerConfigName}'`);
+          this.logger.debug(() => `Starting debug session configuration '${debuggerConfigName}'`);
         }
 
         const deferredDebugSessionStart = new DeferredPromise();

--- a/src/core/main-factory.ts
+++ b/src/core/main-factory.ts
@@ -40,6 +40,11 @@ import { DefaultTestManager } from './default-test-manager';
 import { FileWatcher, FileWatcherOptions } from './file-watcher';
 import { AstTestDefinitionProvider } from './parser/ast/ast-test-definition-provider';
 import { AstTestFileParser } from './parser/ast/ast-test-file-parser';
+import { ForEachNodeProcessor } from './parser/ast/processors/for-each-node-processor';
+import { ForLoopNodeProcessor } from './parser/ast/processors/for-loop-node-processor';
+import { TestAndSuiteNodeProcessor } from './parser/ast/processors/test-and-suite-node-processor';
+import { TestDescriptionNodeProcessor } from './parser/ast/processors/test-description-node-processor';
+import { ProcessedSourceNode, SourceNodeProcessor } from './parser/ast/source-node-processor';
 import { RegexpTestDefinitionProvider } from './parser/regexp/regexp-test-definition-provider';
 import { RegexpTestFileParser } from './parser/regexp/regexp-test-file-parser';
 import { TestHelper } from './test-helper';
@@ -274,7 +279,7 @@ export class MainFactory {
       [...this.config.testFiles],
       testDefinitionProvider,
       fileHandler,
-      new SimpleLogger(this.logger, TestLocator.name),
+      this.createLogger(TestLocator.name),
       testLocatorOptions
     );
   }
@@ -290,7 +295,7 @@ export class MainFactory {
 
     const testFileParser: RegexpTestFileParser = new RegexpTestFileParser(
       this.testFramework.getTestInterface(),
-      new SimpleLogger(this.logger, RegexpTestFileParser.name)
+      this.createLogger(RegexpTestFileParser.name)
     );
 
     const testDefinitionProvider = new RegexpTestDefinitionProvider(
@@ -303,9 +308,23 @@ export class MainFactory {
   private createAstTestDefinitionProvider(): AstTestDefinitionProvider {
     this.logger.debug(() => 'Creating AST test definition provider');
 
+    const testDescriptionNodeProcessor = new TestDescriptionNodeProcessor(
+      this.createLogger(TestDescriptionNodeProcessor.name)
+    );
+
+    const sourceNodeProcessors: SourceNodeProcessor<ProcessedSourceNode>[] = [
+      new TestAndSuiteNodeProcessor(
+        this.testFramework.getTestInterface(),
+        testDescriptionNodeProcessor,
+        this.createLogger(TestAndSuiteNodeProcessor.name)
+      ),
+      new ForEachNodeProcessor(this.createLogger(ForEachNodeProcessor.name)),
+      new ForLoopNodeProcessor(this.createLogger(ForLoopNodeProcessor.name))
+    ];
+
     const testFileParser: AstTestFileParser = new AstTestFileParser(
-      this.testFramework.getTestInterface(),
-      new SimpleLogger(this.logger, AstTestFileParser.name)
+      sourceNodeProcessors,
+      this.createLogger(AstTestFileParser.name)
     );
 
     const testDefinitionProvider = new AstTestDefinitionProvider(
@@ -458,7 +477,7 @@ export class MainFactory {
       debugStatusResolver,
       testDiscoveryEventProcessingOptions,
       testRunEventProcessingOptions,
-      new SimpleLogger(this.logger, KarmaTestRunProcessor.name)
+      this.createLogger(KarmaTestRunProcessor.name)
     );
 
     return new KarmaTestListener(testRunProcessor, this.createLogger(KarmaTestListener.name), {

--- a/src/core/main-factory.ts
+++ b/src/core/main-factory.ts
@@ -41,7 +41,8 @@ import { FileWatcher, FileWatcherOptions } from './file-watcher';
 import { AstTestDefinitionProvider } from './parser/ast/ast-test-definition-provider';
 import { AstTestFileParser } from './parser/ast/ast-test-file-parser';
 import { ForEachNodeProcessor } from './parser/ast/processors/for-each-node-processor';
-import { ForLoopNodeProcessor } from './parser/ast/processors/for-loop-node-processor';
+import { IfElseNodeProcessor } from './parser/ast/processors/if-else-node-processor';
+import { LoopNodeProcessor } from './parser/ast/processors/loop-node-processor';
 import { TestAndSuiteNodeProcessor } from './parser/ast/processors/test-and-suite-node-processor';
 import { TestDescriptionNodeProcessor } from './parser/ast/processors/test-description-node-processor';
 import { ProcessedSourceNode, SourceNodeProcessor } from './parser/ast/source-node-processor';
@@ -319,7 +320,8 @@ export class MainFactory {
         this.createLogger(TestAndSuiteNodeProcessor.name)
       ),
       new ForEachNodeProcessor(this.createLogger(ForEachNodeProcessor.name)),
-      new ForLoopNodeProcessor(this.createLogger(ForLoopNodeProcessor.name))
+      new LoopNodeProcessor(this.createLogger(LoopNodeProcessor.name)),
+      new IfElseNodeProcessor(this.createLogger(IfElseNodeProcessor.name))
     ];
 
     const testFileParser: AstTestFileParser = new AstTestFileParser(

--- a/src/core/parser/ast/described-test-definition.ts
+++ b/src/core/parser/ast/described-test-definition.ts
@@ -1,0 +1,23 @@
+import { TestDefinition } from '../../base/test-definition';
+
+export enum DescribedTestDefinitionType {
+  String = 'string',
+  Pattern = 'pattern'
+}
+
+export type DescribedTestDefinition = StringDescribedTestDefinition | PatternDescribedTestDefinition;
+
+export interface StringDescribedTestDefinition extends TestDefinition {
+  description: string;
+  descriptionType: DescribedTestDefinitionType.String;
+}
+
+export interface PatternDescribedTestDefinition extends TestDefinition {
+  description: RegExp;
+  descriptionType: DescribedTestDefinitionType.Pattern;
+}
+
+export interface DescribedTestDefinitionInfo {
+  test: DescribedTestDefinition;
+  suite: DescribedTestDefinition[];
+}

--- a/src/core/parser/ast/processors/for-each-node-processor.ts
+++ b/src/core/parser/ast/processors/for-each-node-processor.ts
@@ -1,0 +1,57 @@
+import { Node } from '@babel/core';
+import { Disposable } from 'vscode';
+import { Disposer } from '../../../../util/disposable/disposer';
+import { Logger } from '../../../../util/logging/logger';
+import { ProcessedSourceNode, SourceNodeProcessor } from '../source-node-processor';
+
+export class ForEachNodeProcessor implements SourceNodeProcessor<ProcessedSourceNode> {
+  private readonly disposables: Disposable[] = [];
+
+  public constructor(private readonly logger: Logger) {
+    this.disposables.push(logger);
+  }
+
+  public processNode(node: Node): ProcessedSourceNode | undefined {
+    if (node.type !== 'ExpressionStatement' || node.expression.type !== 'CallExpression') {
+      this.logger.trace(() => `Rejecting source node of type: ${node.type}`);
+      return undefined;
+    }
+    this.logger.trace(() => `Processing source node of type: ${node.type}`);
+
+    const expressionNode = node.expression;
+    const calleeNode = expressionNode.callee;
+
+    const isForEachExpression =
+      calleeNode.type === 'MemberExpression' &&
+      calleeNode.property.type === 'Identifier' &&
+      calleeNode.property.name === 'forEach';
+
+    if (!isForEachExpression) {
+      return undefined;
+    }
+
+    const testImplementationNode = expressionNode.arguments[0];
+
+    const testNodeHasFunctionImplementation =
+      testImplementationNode?.type === 'FunctionExpression' ||
+      testImplementationNode?.type === 'ArrowFunctionExpression';
+
+    const childNodes =
+      testNodeHasFunctionImplementation && testImplementationNode?.body?.type === 'BlockStatement'
+        ? testImplementationNode.body.body
+        : undefined;
+
+    const processedNode: ProcessedSourceNode = {
+      childNodes: childNodes ?? []
+    };
+
+    this.logger.trace(
+      () => `Successfully processed source node of type '${node.type}' to ${childNodes?.length ?? 0} child nodes`
+    );
+    return processedNode;
+  }
+
+  public async dispose() {
+    await Disposer.dispose(this.disposables);
+  }
+}

--- a/src/core/parser/ast/processors/for-loop-node-processor.ts
+++ b/src/core/parser/ast/processors/for-loop-node-processor.ts
@@ -1,0 +1,38 @@
+import { Node } from '@babel/core';
+import { Disposable } from 'vscode';
+import { Disposer } from '../../../../util/disposable/disposer';
+import { Logger } from '../../../../util/logging/logger';
+import { ProcessedSourceNode, SourceNodeProcessor } from '../source-node-processor';
+
+export class ForLoopNodeProcessor implements SourceNodeProcessor<ProcessedSourceNode> {
+  private readonly disposables: Disposable[] = [];
+
+  public constructor(private readonly logger: Logger) {
+    this.disposables.push(logger);
+  }
+
+  public processNode(node: Node): ProcessedSourceNode | undefined {
+    const nodeIsForLoopVariant =
+      node.type === 'ForStatement' || node.type === 'ForInStatement' || node.type === 'ForOfStatement';
+
+    if (!nodeIsForLoopVariant || node.body.type !== 'BlockStatement') {
+      this.logger.trace(() => `Rejecting source node of type: ${node.type}`);
+      return undefined;
+    }
+    this.logger.trace(() => `Processing source node of type: ${node.type}`);
+    const childNodes = node.body.body;
+
+    const processedNode: ProcessedSourceNode = {
+      childNodes: childNodes
+    };
+
+    this.logger.trace(
+      () => `Successfully processed source node of type '${node.type}' to ${childNodes?.length ?? 0} child nodes`
+    );
+    return processedNode;
+  }
+
+  public async dispose() {
+    await Disposer.dispose(this.disposables);
+  }
+}

--- a/src/core/parser/ast/processors/if-else-node-processor.ts
+++ b/src/core/parser/ast/processors/if-else-node-processor.ts
@@ -1,0 +1,56 @@
+import { Node } from '@babel/core';
+import { IfStatement } from '@babel/types';
+import { Disposable } from 'vscode';
+import { Disposer } from '../../../../util/disposable/disposer';
+import { Logger } from '../../../../util/logging/logger';
+import { ProcessedSourceNode, SourceNodeProcessor } from '../source-node-processor';
+
+export class IfElseNodeProcessor implements SourceNodeProcessor<ProcessedSourceNode> {
+  private readonly disposables: Disposable[] = [];
+
+  public constructor(private readonly logger: Logger) {
+    this.disposables.push(logger);
+  }
+
+  public processNode(node: Node): ProcessedSourceNode | undefined {
+    if (node.type !== 'IfStatement') {
+      this.logger.trace(() => `Rejecting source node of type: ${node.type}`);
+      return undefined;
+    }
+    this.logger.trace(() => `Processing source node of type: ${node.type}`);
+
+    const childNodes = this.processIfStatementNode(node);
+    const processedNode: ProcessedSourceNode = { childNodes };
+
+    this.logger.trace(
+      () => `Successfully processed source node of type '${node.type}' to ${childNodes?.length ?? 0} child nodes`
+    );
+    return processedNode;
+  }
+
+  private processIfStatementNode(node: IfStatement): Node[] {
+    const ifNode = node.consequent;
+    const elseNode = node.alternate;
+
+    const ifNodeChildren: Node[] =
+      ifNode.type === 'BlockStatement'
+        ? ifNode.body
+        : ifNode.type === 'IfStatement'
+        ? this.processIfStatementNode(ifNode)
+        : [];
+
+    const elseNodeChildren: Node[] =
+      elseNode?.type === 'BlockStatement'
+        ? elseNode.body
+        : elseNode?.type === 'IfStatement'
+        ? this.processIfStatementNode(elseNode)
+        : [];
+
+    const combinedChildNodes = [...ifNodeChildren, ...elseNodeChildren];
+    return combinedChildNodes;
+  }
+
+  public async dispose() {
+    await Disposer.dispose(this.disposables);
+  }
+}

--- a/src/core/parser/ast/processors/loop-node-processor.ts
+++ b/src/core/parser/ast/processors/loop-node-processor.ts
@@ -4,7 +4,7 @@ import { Disposer } from '../../../../util/disposable/disposer';
 import { Logger } from '../../../../util/logging/logger';
 import { ProcessedSourceNode, SourceNodeProcessor } from '../source-node-processor';
 
-export class ForLoopNodeProcessor implements SourceNodeProcessor<ProcessedSourceNode> {
+export class LoopNodeProcessor implements SourceNodeProcessor<ProcessedSourceNode> {
   private readonly disposables: Disposable[] = [];
 
   public constructor(private readonly logger: Logger) {
@@ -12,10 +12,14 @@ export class ForLoopNodeProcessor implements SourceNodeProcessor<ProcessedSource
   }
 
   public processNode(node: Node): ProcessedSourceNode | undefined {
-    const nodeIsForLoopVariant =
-      node.type === 'ForStatement' || node.type === 'ForInStatement' || node.type === 'ForOfStatement';
+    const isLoopNode =
+      node.type === 'ForStatement' ||
+      node.type === 'ForInStatement' ||
+      node.type === 'ForOfStatement' ||
+      node.type === 'WhileStatement' ||
+      node.type === 'DoWhileStatement';
 
-    if (!nodeIsForLoopVariant || node.body.type !== 'BlockStatement') {
+    if (!isLoopNode || node.body.type !== 'BlockStatement') {
       this.logger.trace(() => `Rejecting source node of type: ${node.type}`);
       return undefined;
     }

--- a/src/core/parser/ast/processors/test-and-suite-node-processor.ts
+++ b/src/core/parser/ast/processors/test-and-suite-node-processor.ts
@@ -1,0 +1,133 @@
+import { Node } from '@babel/core';
+import { Disposable } from 'vscode';
+import { Disposer } from '../../../../util/disposable/disposer';
+import { Logger } from '../../../../util/logging/logger';
+import { regexJsonReplacer } from '../../../../util/utils';
+import { TestDefinitionState } from '../../../base/test-definition';
+import { TestInterface } from '../../../base/test-framework';
+import { TestType } from '../../../base/test-infos';
+import { ProcessedSourceNode, SourceNodeDetail, SourceNodeProcessor } from '../source-node-processor';
+import { TestDescriptionNodeProcessor } from './test-description-node-processor';
+
+export class TestAndSuiteNodeProcessor implements SourceNodeProcessor<ProcessedSourceNode> {
+  private readonly disposables: Disposable[] = [];
+  private readonly suiteTags: string[];
+  private readonly testTags: string[];
+
+  public constructor(
+    private readonly testInterface: TestInterface,
+    private readonly testDescriptionNodeProcessor: TestDescriptionNodeProcessor,
+    private readonly logger: Logger
+  ) {
+    this.disposables.push(logger);
+
+    this.suiteTags = [
+      ...testInterface.suiteTags.default,
+      ...testInterface.suiteTags.focused,
+      ...testInterface.suiteTags.disabled
+    ];
+    this.testTags = [
+      ...testInterface.testTags.default,
+      ...testInterface.testTags.focused,
+      ...testInterface.testTags.disabled
+    ];
+  }
+
+  public processNode(node: Node): ProcessedSourceNode | undefined {
+    if (node.type !== 'ExpressionStatement' || node.expression.type !== 'CallExpression') {
+      this.logger.trace(() => `Rejecting source node of type: ${node.type}`);
+      return undefined;
+    }
+    this.logger.trace(() => `Processing source node of type: ${node.type}`);
+
+    const expressionNode = node.expression;
+    const calleeNode = expressionNode.callee;
+
+    const testTag: string | undefined =
+      calleeNode.type === 'Identifier'
+        ? calleeNode.name
+        : calleeNode.type === 'MemberExpression' &&
+          calleeNode.object.type === 'Identifier' &&
+          calleeNode.property.type === 'Identifier'
+        ? `${calleeNode.object.name}.${calleeNode.property.name}`
+        : undefined;
+
+    if (!testTag) {
+      return undefined;
+    }
+
+    const testDefinitionType: TestType | undefined = this.suiteTags.includes(testTag)
+      ? TestType.Suite
+      : this.testTags.includes(testTag)
+      ? TestType.Test
+      : undefined;
+
+    if (!testDefinitionType) {
+      return undefined;
+    }
+
+    const testTags = testDefinitionType === TestType.Suite ? this.testInterface.suiteTags : this.testInterface.testTags;
+
+    const testDefinitionState: TestDefinitionState | undefined = testTags.default.includes(testTag)
+      ? TestDefinitionState.Default
+      : testTags.focused.includes(testTag)
+      ? TestDefinitionState.Focused
+      : testTags.disabled.includes(testTag)
+      ? TestDefinitionState.Disabled
+      : undefined;
+
+    if (!testDefinitionState) {
+      return undefined;
+    }
+
+    const testDescriptionNode = expressionNode.arguments[0];
+    const processedTestDescription = this.testDescriptionNodeProcessor.processNode(testDescriptionNode);
+
+    if (processedTestDescription === undefined) {
+      return undefined;
+    }
+
+    const locationNode = calleeNode.loc;
+
+    if (!locationNode) {
+      return undefined;
+    }
+
+    const nodeDetail: SourceNodeDetail = {
+      ...processedTestDescription,
+      type: testDefinitionType,
+      state: testDefinitionState,
+      line: locationNode.start.line
+    };
+
+    const testImplementationNode = expressionNode.arguments[1];
+
+    const testNodeHasFunctionImplementation =
+      testImplementationNode?.type === 'FunctionExpression' ||
+      testImplementationNode?.type === 'ArrowFunctionExpression';
+
+    const childNodes =
+      testDefinitionType === TestType.Suite &&
+      testNodeHasFunctionImplementation &&
+      testImplementationNode?.body?.type === 'BlockStatement'
+        ? testImplementationNode.body.body
+        : undefined;
+
+    const processedNode: ProcessedSourceNode = {
+      nodeDetail,
+      childNodes
+    };
+
+    this.logger.trace(
+      () =>
+        `Successfully processed source node ` +
+        `(having ${childNodes?.length ?? 0} child nodes): ` +
+        `${JSON.stringify(nodeDetail, regexJsonReplacer, 2)}`
+    );
+    return processedNode;
+  }
+
+  public async dispose() {
+    await Disposer.dispose(this.disposables);
+  }
+}

--- a/src/core/parser/ast/processors/test-description-node-processor.ts
+++ b/src/core/parser/ast/processors/test-description-node-processor.ts
@@ -1,0 +1,125 @@
+import { Node } from '@babel/core';
+import { BinaryExpression, NumericLiteral, TemplateLiteral } from '@babel/types';
+import { Disposable } from 'vscode';
+import { Disposer } from '../../../../util/disposable/disposer';
+import { Logger } from '../../../../util/logging/logger';
+import { escapeForRegExp, regexJsonReplacer } from '../../../../util/utils';
+import {
+  DescribedTestDefinitionType,
+  PatternDescribedTestDefinition,
+  StringDescribedTestDefinition
+} from '../described-test-definition';
+import { SourceNodeProcessor } from '../source-node-processor';
+
+type StringOrPattern = { text: string; isPattern: boolean };
+
+export type ProcessedTestDescription =
+  | Pick<StringDescribedTestDefinition, 'description' | 'descriptionType'>
+  | Pick<PatternDescribedTestDefinition, 'description' | 'descriptionType'>;
+
+export class TestDescriptionNodeProcessor implements SourceNodeProcessor<ProcessedTestDescription> {
+  private readonly disposables: Disposable[] = [];
+
+  public constructor(private readonly logger: Logger) {
+    this.disposables.push(logger);
+  }
+
+  public processNode(node: Node): ProcessedTestDescription | undefined {
+    const descriptionStringOrPattern: StringOrPattern | undefined =
+      node.type === 'StringLiteral'
+        ? { text: node.value, isPattern: false }
+        : node.type === 'TemplateLiteral'
+        ? this.processTemplateLiteralNode(node)
+        : node.type === 'NumericLiteral'
+        ? this.processNumericLiteralNode(node)
+        : node.type === 'BinaryExpression'
+        ? this.processBinaryExpressionNode(node)
+        : undefined;
+
+    if (!descriptionStringOrPattern) {
+      this.logger.trace(() => `Rejecting source node of type: ${node.type}`);
+      return undefined;
+    }
+    this.logger.trace(() => `Processing source node of type: ${node.type}`);
+
+    const processedDescription: ProcessedTestDescription = descriptionStringOrPattern.isPattern
+      ? {
+          description: new RegExp(`^${descriptionStringOrPattern.text}$`),
+          descriptionType: DescribedTestDefinitionType.Pattern
+        }
+      : {
+          description: descriptionStringOrPattern.text,
+          descriptionType: DescribedTestDefinitionType.String
+        };
+
+    this.logger.trace(
+      () =>
+        `Successfully processed source node ` +
+        `of type '${node.type}' with result: ` +
+        `${JSON.stringify(processedDescription, regexJsonReplacer, 2)}`
+    );
+    return processedDescription;
+  }
+
+  private processTemplateLiteralNode(node: TemplateLiteral): StringOrPattern {
+    if (node.quasis.length === 1) {
+      const text = node.quasis[0].value.cooked ?? node.quasis[0].value.raw;
+      return { text, isPattern: false };
+    }
+    const templatePattern = node.quasis.map(templateElement => escapeForRegExp(templateElement.value.raw)).join('(.*)');
+    return { text: templatePattern, isPattern: true };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  private processNumericLiteralNode(node: NumericLiteral): StringOrPattern {
+    return { text: `[-+._0-9]+`, isPattern: true };
+  }
+
+  private processBinaryExpressionNode(node: BinaryExpression): StringOrPattern {
+    const leftNode = node.left;
+    const rightNode = node.right;
+
+    const leftStringOrPattern: StringOrPattern =
+      leftNode.type === 'StringLiteral'
+        ? { text: leftNode.value, isPattern: false }
+        : leftNode.type === 'TemplateLiteral'
+        ? this.processTemplateLiteralNode(leftNode)
+        : leftNode.type === 'NumericLiteral'
+        ? this.processNumericLiteralNode(leftNode)
+        : leftNode.type === 'BinaryExpression'
+        ? this.processBinaryExpressionNode(leftNode)
+        : { text: '(.*)', isPattern: true };
+
+    const rightStringOrPattern: StringOrPattern =
+      rightNode.type === 'StringLiteral'
+        ? { text: rightNode.value, isPattern: false }
+        : rightNode.type === 'TemplateLiteral'
+        ? this.processTemplateLiteralNode(rightNode)
+        : rightNode.type === 'NumericLiteral'
+        ? this.processNumericLiteralNode(rightNode)
+        : rightNode.type === 'BinaryExpression'
+        ? this.processBinaryExpressionNode(rightNode)
+        : { text: '(.*)', isPattern: true };
+
+    const combinedStringOrPattern = this.getCombinedStringOrPattern(leftStringOrPattern, rightStringOrPattern);
+    return combinedStringOrPattern;
+  }
+
+  private getCombinedStringOrPattern(...items: StringOrPattern[]): StringOrPattern {
+    const combinationIsPattern = items.some(item => item.isPattern);
+
+    const combinedString = items
+      .map(item => (combinationIsPattern && !item.isPattern ? escapeForRegExp(item.text) : item.text))
+      .join('');
+
+    const combinedStringOrPattern: StringOrPattern = {
+      text: combinedString,
+      isPattern: combinationIsPattern
+    };
+    return combinedStringOrPattern;
+  }
+
+  public async dispose() {
+    await Disposer.dispose(this.disposables);
+  }
+}

--- a/src/core/parser/ast/source-node-processor.ts
+++ b/src/core/parser/ast/source-node-processor.ts
@@ -1,0 +1,16 @@
+import { Node } from '@babel/core';
+import { Disposable } from '../../../util/disposable/disposable';
+import { PatternDescribedTestDefinition, StringDescribedTestDefinition } from './described-test-definition';
+
+export interface SourceNodeProcessor<T> extends Disposable {
+  processNode(node: Node): T | undefined;
+}
+
+export interface ProcessedSourceNode {
+  nodeDetail?: SourceNodeDetail;
+  childNodes?: Node[];
+}
+
+export type SourceNodeDetail =
+  | Pick<StringDescribedTestDefinition, 'type' | 'description' | 'descriptionType' | 'state' | 'line'>
+  | Pick<PatternDescribedTestDefinition, 'type' | 'description' | 'descriptionType' | 'state' | 'line'>;

--- a/src/core/parser/regexp/regexp-test-file-parser.ts
+++ b/src/core/parser/regexp/regexp-test-file-parser.ts
@@ -4,20 +4,21 @@ import { Logger } from '../../../util/logging/logger';
 import { escapeForRegExp, generateRandomId, stripJsComments } from '../../../util/utils';
 import { TestDefinitionState } from '../../base/test-definition';
 import { TestInterface } from '../../base/test-framework';
-import { TestNode, TestNodeType } from '../../base/test-node';
+import { TestFileParser } from '../test-file-parser';
+import { TestNode, TestNodeType } from './test-node';
 
 export type RegexpTestFileParserResult = Record<TestNodeType, TestNode[]>;
 
-export class RegexpTestFileParser implements Disposable {
+export class RegexpTestFileParser implements TestFileParser<RegexpTestFileParserResult> {
   private disposables: Disposable[] = [];
 
   public constructor(private readonly testInterface: TestInterface, private readonly logger: Logger) {
     this.disposables.push(logger);
   }
 
-  public parseFileText(fileText: string): RegexpTestFileParserResult {
+  public parseFileText(fileText: string, filePath: string): RegexpTestFileParserResult {
     const parseId = generateRandomId();
-    this.logger.trace(() => `Parse operation ${parseId}: Parsing file text: \n${fileText}`);
+    this.logger.trace(() => `Parse operation ${parseId}: Parsing file '${filePath}' having content: \n${fileText}`);
 
     const startTime = new Date();
     const data = this.getTestFileData(fileText);
@@ -52,6 +53,7 @@ export class RegexpTestFileParser implements Disposable {
       () =>
         `Parse operation ${parseId}: ` +
         `Parsed ${fileInfo.Test.length} total tests ` +
+        `from file '${filePath}' ` +
         `in ${elapsedTime.toFixed(2)} secs`
     );
     return fileInfo;

--- a/src/core/parser/regexp/test-node.ts
+++ b/src/core/parser/regexp/test-node.ts
@@ -1,4 +1,4 @@
-import { TestDefinitionState } from './test-definition';
+import { TestDefinitionState } from '../../base/test-definition';
 
 export enum TestNodeType {
   Suite = 'Suite',
@@ -7,7 +7,7 @@ export enum TestNodeType {
 
 export interface TestNode {
   type: TestNodeType;
-  state: TestDefinitionState;
   description: string;
+  state: TestDefinitionState;
   line: number;
 }

--- a/src/core/parser/test-file-parser.ts
+++ b/src/core/parser/test-file-parser.ts
@@ -1,0 +1,5 @@
+import { Disposable } from '../../util/disposable/disposable';
+
+export interface TestFileParser<T> extends Disposable {
+  parseFileText(fileText: string, filePath: string): T;
+}

--- a/src/core/test-locator.ts
+++ b/src/core/test-locator.ts
@@ -86,7 +86,7 @@ export class TestLocator implements Disposable {
         for (const file of filesToRefresh) {
           try {
             const fileText = await this.fileHandler.readFile(file, this.testLocatorOptions.fileEncoding);
-            this.testDefinitionProvider.addFileContent(file, fileText);
+            this.testDefinitionProvider.addFileContent(fileText, file);
             loadedFileCount++;
           } catch (error) {
             this.logger.error(() => `Failed to get tests from spec file ${file}: ${error}`);

--- a/src/core/test-store.ts
+++ b/src/core/test-store.ts
@@ -48,7 +48,7 @@ export class TestStore implements Disposable {
   }
 
   public getTestsByFile(filePath: string): TestInfo[] {
-    const changedTests = Array.from(this.storedTestsById.values()).filter(
+    const changedTests = [...this.storedTestsById.values()].filter(
       loadedTest => loadedTest.file === filePath && loadedTest.type === TestType.Test
     ) as TestInfo[];
 

--- a/src/core/util/test-suite-organizer.ts
+++ b/src/core/util/test-suite-organizer.ts
@@ -80,7 +80,7 @@ export class TestSuiteOrganizer implements Disposable {
     if (unmappedTests.length > 0) {
       const filelessTestsSuiteMessage =
         `${EXTENSION_NAME} could not find the test sources in your project ` +
-        `for the tests in this group. This can occur if the tests:` +
+        `for the tests in this group. This can occur in some scenarios if the tests:` +
         `\n\n` +
         `- Use parameterization \n` +
         `- Use computed test descriptions \n` +

--- a/src/frameworks/angular/angular-test-server-executor.ts
+++ b/src/frameworks/angular/angular-test-server-executor.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { TestServerExecutor } from '../../api/test-server-executor';
-import { EXTENSION_NAME } from '../../constants';
+import { EXTENSION_CONFIG_PREFIX } from '../../constants';
 import { ExternalConfigSetting } from '../../core/config/config-setting';
 import { Disposable } from '../../util/disposable/disposable';
 import { Disposer } from '../../util/disposable/disposer';
@@ -77,10 +77,11 @@ export class AngularTestServerExecutor implements TestServerExecutor {
 
       if (!angularBinaryPath) {
         throw new Error(
-          `Angular CLI does not seem to be installed - You may need ` +
-            `to install your project dependencies or specify the ` +
-            `right path to your project using the ${EXTENSION_NAME} ` +
-            `'${ExternalConfigSetting.Projects}' setting.`
+          `Angular CLI does not seem to be installed. You may ` +
+            `need to install your project dependencies or ` +
+            `specify the right path to your project using the ` +
+            `${EXTENSION_CONFIG_PREFIX}.${ExternalConfigSetting.Projects} ` +
+            `setting.`
         );
       }
 

--- a/src/frameworks/karma/config/karma-configurator.ts
+++ b/src/frameworks/karma/config/karma-configurator.ts
@@ -115,7 +115,7 @@ export class KarmaConfigurator {
   }
 
   private addCustomLauncherDebugPort(customLaucher: CustomLauncher, debugPort: number | undefined) {
-    if (!customLaucher || !debugPort) {
+    if (!customLaucher || debugPort === undefined) {
       return;
     }
     customLaucher.flags = customLaucher.flags?.map(flag =>

--- a/src/frameworks/karma/reporter/karma-test-explorer-reporter.ts
+++ b/src/frameworks/karma/reporter/karma-test-explorer-reporter.ts
@@ -9,7 +9,7 @@ import { LogLevel } from '../../../util/logging/log-level';
 import { Logger } from '../../../util/logging/logger';
 import { LoggerAdapter } from '../../../util/logging/logger-adapter';
 import { MultiEventHandler } from '../../../util/multi-event-handler';
-import { getCircularReferenceReplacer } from '../../../util/utils';
+import { getJsonCircularReferenceReplacer } from '../../../util/utils';
 import { KarmaEnvironmentVariable } from '../karma-environment-variable';
 import { BrowserInfo, KarmaEvent, KarmaEventName } from '../runner/karma-event';
 import { LightSpecCompleteResponse } from '../runner/spec-complete-response';
@@ -75,7 +75,7 @@ export function KarmaTestExplorerReporter(
       logger.trace(
         () =>
           `No specific handler for received error event '${eventName}' with data: ` +
-          `${JSON.stringify(args, getCircularReferenceReplacer(), 2)}`
+          `${JSON.stringify(args, getJsonCircularReferenceReplacer(), 2)}`
       );
     }
     sendEvent({ name: eventName as KarmaEventName });
@@ -86,12 +86,14 @@ export function KarmaTestExplorerReporter(
     logger.trace(
       () =>
         `Event data for errored '${eventName}' event handling: ` +
-        `${JSON.stringify(args, getCircularReferenceReplacer(), 2)}`
+        `${JSON.stringify(args, getJsonCircularReferenceReplacer(), 2)}`
     );
   });
 
   interceptAllEmitterEvents(emitter, (eventName: string, ...args: any[]) => {
-    logger.trace(() => `New Karma event: ${JSON.stringify({ eventName, args }, getCircularReferenceReplacer(), 2)}`);
+    logger.trace(
+      () => `New Karma event: ${JSON.stringify({ eventName, args }, getJsonCircularReferenceReplacer(), 2)}`
+    );
     karmaEventHandler.handleEvent(eventName as KarmaEventName, eventName as KarmaEventName, ...args);
   });
 
@@ -122,7 +124,9 @@ export function KarmaTestExplorerReporter(
   });
 
   karmaEventHandler.setEventHandler(KarmaEventName.BrowserStart, (name: KarmaEventName, browser: any, info: any) => {
-    logger.trace(() => `Karma event '${name}' has 'info': ${JSON.stringify(info, getCircularReferenceReplacer(), 2)}`);
+    logger.trace(
+      () => `Karma event '${name}' has 'info': ${JSON.stringify(info, getJsonCircularReferenceReplacer(), 2)}`
+    );
 
     sendEvent({
       name,
@@ -160,7 +164,7 @@ export function KarmaTestExplorerReporter(
     KarmaEventName.BrowserComplete,
     (name: KarmaEventName, browser: any, runInfo: any) => {
       logger.trace(
-        () => `Karma event '${name}' has 'runInfo': ${JSON.stringify(runInfo, getCircularReferenceReplacer(), 2)}`
+        () => `Karma event '${name}' has 'runInfo': ${JSON.stringify(runInfo, getJsonCircularReferenceReplacer(), 2)}`
       );
 
       sendEvent({

--- a/src/frameworks/karma/runner/karma-command-line-test-run-executor.ts
+++ b/src/frameworks/karma/runner/karma-command-line-test-run-executor.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { TestRunExecutor } from '../../../api/test-run-executor';
-import { EXTENSION_NAME } from '../../../constants';
+import { EXTENSION_CONFIG_PREFIX } from '../../../constants';
 import { ExternalConfigSetting } from '../../../core/config/config-setting';
 import { Disposable } from '../../../util/disposable/disposable';
 import { Disposer } from '../../../util/disposable/disposer';
@@ -53,10 +53,11 @@ export class KarmaCommandLineTestRunExecutor implements TestRunExecutor {
 
       if (!karmaBinaryPath) {
         throw new Error(
-          `Karma does not seem to be installed - You may need ` +
-            `to install your project dependencies or specify the ` +
-            `right path to your project using the ${EXTENSION_NAME} ` +
-            `'${ExternalConfigSetting.Projects}' setting.`
+          `Karma does not seem to be installed. You may ` +
+            `need to install your project dependencies or ` +
+            `specify the right path to your project using the ` +
+            `${EXTENSION_CONFIG_PREFIX}.${ExternalConfigSetting.Projects} ` +
+            `setting.`
         );
       }
 

--- a/src/frameworks/karma/runner/karma-test-event-processor.ts
+++ b/src/frameworks/karma/runner/karma-test-event-processor.ts
@@ -111,8 +111,8 @@ export class KarmaTestEventProcessor {
       this.logger.debug(() => `Test event processor is currently processing - Concluding current processing`);
 
       const processedResults: TestEventProcessingResults = {
-        processedSpecs: Array.from(this.currentProcessingInfo.processedTestResults.values()),
-        filteredEvents: Array.from(this.currentProcessingInfo.filteredTestResultEvents.values())
+        processedSpecs: [...this.currentProcessingInfo.processedTestResults.values()],
+        filteredEvents: [...this.currentProcessingInfo.filteredTestResultEvents.values()]
       };
       this.currentProcessingInfo.deferredProcessingResults!.fulfill(processedResults);
       this.emitTestSuiteEvents();
@@ -327,7 +327,7 @@ export class KarmaTestEventProcessor {
       [TestStatus.Skipped]: []
     };
 
-    Array.from(this.currentProcessingInfo.processedTestResults.values()).forEach(processedSpec =>
+    [...this.currentProcessingInfo.processedTestResults.values()].forEach(processedSpec =>
       capturedTests[processedSpec.status].push(processedSpec)
     );
 

--- a/src/frameworks/karma/server/karma-command-line-test-server-executor.ts
+++ b/src/frameworks/karma/server/karma-command-line-test-server-executor.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { TestServerExecutor } from '../../../api/test-server-executor';
-import { EXTENSION_NAME } from '../../../constants';
+import { EXTENSION_CONFIG_PREFIX, EXTENSION_NAME } from '../../../constants';
 import { ExternalConfigSetting } from '../../../core/config/config-setting';
 import { Disposable } from '../../../util/disposable/disposable';
 import { Disposer } from '../../../util/disposable/disposer';
@@ -77,10 +77,11 @@ export class KarmaCommandLineTestServerExecutor implements TestServerExecutor {
 
       if (!karmaBinaryPath) {
         throw new Error(
-          `Karma does not seem to be installed - You may need ` +
-            `to install your project dependencies or specify the ` +
-            `right path to your project using the ${EXTENSION_NAME} ` +
-            `'${ExternalConfigSetting.Projects}' setting.`
+          `Karma does not seem to be installed. You may ` +
+            `need to install your project dependencies or ` +
+            `specify the right path to your project using the ` +
+            `${EXTENSION_CONFIG_PREFIX}.${ExternalConfigSetting.Projects} ` +
+            `setting.`
         );
       }
 

--- a/src/project-factory.ts
+++ b/src/project-factory.ts
@@ -38,6 +38,8 @@ export class ProjectFactory implements Disposable {
   }
 
   private createProjectsForWorkspaceFolder(workspaceFolder: WorkspaceFolder): WorkspaceProject[] {
+    this.logger.debug(() => `Inspecting workspace folder for testing: ${workspaceFolder.uri.fsPath}`);
+
     if (workspaceFolder.uri.scheme !== 'file') {
       this.logger.debug(() => `Excluding projects in non-file scheme workspace folder: ${workspaceFolder.uri.fsPath}`);
       return [];

--- a/src/util/disposable/disposer.ts
+++ b/src/util/disposable/disposer.ts
@@ -29,7 +29,7 @@ export class Disposer {
     if (distinctDisposables.size === 0) {
       return;
     }
-    const diposals = Array.from(distinctDisposables).map(disposable => this.disposeItems(disposable));
+    const diposals = [...distinctDisposables].map(disposable => this.disposeItems(disposable));
     disposables.splice(0, disposables.length);
 
     await RichPromise.allSettled(diposals);

--- a/src/util/process/simple-process.ts
+++ b/src/util/process/simple-process.ts
@@ -163,7 +163,7 @@ export class SimpleProcess implements Process {
       return this.processCurrentlyStopping;
     }
 
-    const runningProcess = this.childProcess!;
+    const runningProcess = this.childProcess;
     this.logger.debug(() => `Process ${this.uid} - Killing process tree of PID: ${runningProcess.pid}`);
 
     const futureProcessTermination = new RichPromise<void>((resolve, reject) => {

--- a/src/util/utils.ts
+++ b/src/util/utils.ts
@@ -120,7 +120,7 @@ export const getLongestCommonPath = (filePaths: string[]): string | undefined =>
 };
 
 // From MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Cyclic_object_value
-export const getCircularReferenceReplacer = () => {
+export const getJsonCircularReferenceReplacer = () => {
   const seen = new WeakSet();
   return (key: string, value: unknown) => {
     if (typeof value === 'object' && value !== null) {
@@ -131,6 +131,13 @@ export const getCircularReferenceReplacer = () => {
     }
     return value;
   };
+};
+
+export const regexJsonReplacer = (key: string, value: unknown) => {
+  if (value instanceof RegExp) {
+    return value.source;
+  }
+  return value;
 };
 
 export const expandEnvironment = (

--- a/test/core/parser/ast/ast-test-definition-provider.test.ts
+++ b/test/core/parser/ast/ast-test-definition-provider.test.ts
@@ -1,0 +1,205 @@
+import { mock, MockProxy } from 'jest-mock-extended';
+import { TestDefinitionState } from '../../../../src/core/base/test-definition';
+import { TestDefinitionProvider } from '../../../../src/core/base/test-definition-provider';
+import { TestType } from '../../../../src/core/base/test-infos';
+import { AstTestDefinitionProvider } from '../../../../src/core/parser/ast/ast-test-definition-provider';
+import { AstTestFileParser } from '../../../../src/core/parser/ast/ast-test-file-parser';
+import {
+  DescribedTestDefinitionInfo,
+  DescribedTestDefinitionType
+} from '../../../../src/core/parser/ast/described-test-definition';
+import { Logger } from '../../../../src/util/logging/logger';
+
+describe('AstTestDefinitionProvider', () => {
+  let mockLogger: MockProxy<Logger>;
+  let mockAstTestFileParser: MockProxy<AstTestFileParser>;
+  let testDefinitionProvider: TestDefinitionProvider;
+
+  beforeEach(() => {
+    mockLogger = mock<Logger>();
+    mockAstTestFileParser = mock<AstTestFileParser>();
+    testDefinitionProvider = new AstTestDefinitionProvider(mockAstTestFileParser, mockLogger);
+  });
+
+  describe('when test file content having nested suites and identical descriptions is added', () => {
+    const mockTestFileText = '';
+    const mockTestFilePath = 'path/to/random/test/file';
+
+    beforeEach(async () => {
+      mockAstTestFileParser.parseFileText.mockReturnValue(<DescribedTestDefinitionInfo[]>[
+        {
+          suite: [
+            {
+              type: TestType.Suite,
+              description: 'test suite 1',
+              descriptionType: DescribedTestDefinitionType.String,
+              file: mockTestFilePath,
+              line: 1,
+              state: TestDefinitionState.Default,
+              disabled: false
+            },
+            {
+              type: TestType.Suite,
+              description: 'test suite 1-1',
+              descriptionType: DescribedTestDefinitionType.String,
+              file: mockTestFilePath,
+              line: 2,
+              state: TestDefinitionState.Default,
+              disabled: false
+            },
+            {
+              type: TestType.Suite,
+              description: 'identical inner suite',
+              descriptionType: DescribedTestDefinitionType.String,
+              file: mockTestFilePath,
+              line: 3,
+              state: TestDefinitionState.Default,
+              disabled: false
+            }
+          ],
+          test: {
+            type: TestType.Test,
+            description: 'identical inner test',
+            descriptionType: DescribedTestDefinitionType.String,
+            file: mockTestFilePath,
+            line: 4,
+            state: TestDefinitionState.Default,
+            disabled: false
+          }
+        },
+        {
+          suite: [
+            {
+              type: TestType.Suite,
+              description: 'test suite 1',
+              descriptionType: DescribedTestDefinitionType.String,
+              file: mockTestFilePath,
+              line: 1,
+              state: TestDefinitionState.Default,
+              disabled: false
+            },
+            {
+              type: TestType.Suite,
+              description: 'test suite 1-2',
+              descriptionType: DescribedTestDefinitionType.String,
+              file: mockTestFilePath,
+              line: 9,
+              state: TestDefinitionState.Default,
+              disabled: false
+            },
+            {
+              type: TestType.Suite,
+              description: 'identical inner suite',
+              descriptionType: DescribedTestDefinitionType.String,
+              file: mockTestFilePath,
+              line: 10,
+              state: TestDefinitionState.Default,
+              disabled: false
+            }
+          ],
+          test: {
+            type: TestType.Test,
+            description: 'identical inner test',
+            descriptionType: DescribedTestDefinitionType.String,
+            file: mockTestFilePath,
+            line: 11,
+            state: TestDefinitionState.Default,
+            disabled: false
+          }
+        }
+      ]);
+      testDefinitionProvider.addFileContent(mockTestFileText, mockTestFilePath);
+    });
+
+    describe('the get test definitions method', () => {
+      it('should return the correct test definitions for the occurring identical test descriptions', () => {
+        const identicalTestDefinition1 = testDefinitionProvider.getTestDefinitions(
+          ['test suite 1', 'test suite 1-1', 'identical inner suite'],
+          'identical inner test'
+        );
+        const identicalTestDefinition2 = testDefinitionProvider.getTestDefinitions(
+          ['test suite 1', 'test suite 1-2', 'identical inner suite'],
+          'identical inner test'
+        );
+
+        expect(identicalTestDefinition1).toEqual([
+          {
+            test: expect.objectContaining({
+              // 'identical inner test',
+              type: TestType.Test,
+              state: TestDefinitionState.Default,
+              disabled: false,
+              file: mockTestFilePath,
+              line: 4
+            }),
+            suite: expect.arrayContaining([
+              expect.objectContaining({
+                // 'test suite 1',
+                type: TestType.Suite,
+                state: TestDefinitionState.Default,
+                disabled: false,
+                file: mockTestFilePath,
+                line: 1
+              }),
+              expect.objectContaining({
+                // 'test suite 1-1',
+                type: TestType.Suite,
+                state: TestDefinitionState.Default,
+                disabled: false,
+                file: mockTestFilePath,
+                line: 2
+              }),
+              expect.objectContaining({
+                // 'identical inner suite',
+                type: TestType.Suite,
+                state: TestDefinitionState.Default,
+                disabled: false,
+                file: mockTestFilePath,
+                line: 3
+              })
+            ])
+          }
+        ]);
+
+        expect(identicalTestDefinition2).toEqual([
+          {
+            test: expect.objectContaining({
+              // 'identical inner test',
+              type: TestType.Test,
+              state: TestDefinitionState.Default,
+              disabled: false,
+              file: mockTestFilePath,
+              line: 11
+            }),
+            suite: expect.arrayContaining([
+              expect.objectContaining({
+                // 'test suite 1',
+                type: TestType.Suite,
+                state: TestDefinitionState.Default,
+                disabled: false,
+                file: mockTestFilePath,
+                line: 1
+              }),
+              expect.objectContaining({
+                // 'test suite 1-2',
+                type: TestType.Suite,
+                state: TestDefinitionState.Default,
+                disabled: false,
+                file: mockTestFilePath,
+                line: 9
+              }),
+              expect.objectContaining({
+                // 'identical inner suite',
+                type: TestType.Suite,
+                state: TestDefinitionState.Default,
+                disabled: false,
+                file: mockTestFilePath,
+                line: 10
+              })
+            ])
+          }
+        ]);
+      });
+    });
+  });
+});

--- a/test/core/parser/regexp/regexp-test-definition-provider.test.ts
+++ b/test/core/parser/regexp/regexp-test-definition-provider.test.ts
@@ -1,0 +1,171 @@
+import { mock, MockProxy } from 'jest-mock-extended';
+import { TestDefinitionState } from '../../../../src/core/base/test-definition';
+import { TestDefinitionProvider } from '../../../../src/core/base/test-definition-provider';
+import { TestType } from '../../../../src/core/base/test-infos';
+import { RegexpTestDefinitionProvider } from '../../../../src/core/parser/regexp/regexp-test-definition-provider';
+import {
+  RegexpTestFileParser,
+  RegexpTestFileParserResult
+} from '../../../../src/core/parser/regexp/regexp-test-file-parser';
+import { TestNodeType } from '../../../../src/core/parser/regexp/test-node';
+import { Logger } from '../../../../src/util/logging/logger';
+
+describe('RegexpTestDefinitionProvider', () => {
+  let mockLogger: MockProxy<Logger>;
+  let mockRegexTestFileParser: MockProxy<RegexpTestFileParser>;
+  let testDefinitionProvider: TestDefinitionProvider;
+
+  beforeEach(() => {
+    mockLogger = mock<Logger>();
+    mockRegexTestFileParser = mock<RegexpTestFileParser>();
+    testDefinitionProvider = new RegexpTestDefinitionProvider(mockRegexTestFileParser, mockLogger);
+  });
+
+  describe('when test file content having nested suites and identical descriptions is added', () => {
+    const mockTestFileText = '';
+    const mockTestFilePath = 'path/to/random/test/file';
+
+    beforeEach(async () => {
+      mockRegexTestFileParser.parseFileText.mockReturnValue(<RegexpTestFileParserResult>{
+        Suite: [
+          {
+            type: TestNodeType.Suite,
+            description: 'test suite 1',
+            line: 1,
+            state: TestDefinitionState.Default
+          },
+          {
+            type: TestNodeType.Suite,
+            description: 'test suite 1-1',
+            line: 2,
+            state: TestDefinitionState.Default
+          },
+          {
+            type: TestNodeType.Suite,
+            description: 'identical inner suite',
+            line: 3,
+            state: TestDefinitionState.Default
+          },
+          {
+            type: TestNodeType.Suite,
+            description: 'test suite 1-2',
+            line: 9,
+            state: TestDefinitionState.Default
+          },
+          {
+            type: TestNodeType.Suite,
+            description: 'identical inner suite',
+            line: 10,
+            state: TestDefinitionState.Default
+          }
+        ],
+        Test: [
+          {
+            type: TestNodeType.Test,
+            description: 'identical inner test',
+            line: 4,
+            state: TestDefinitionState.Default
+          },
+          {
+            type: TestNodeType.Test,
+            description: 'identical inner test',
+            line: 11,
+            state: TestDefinitionState.Default
+          }
+        ]
+      });
+      testDefinitionProvider.addFileContent(mockTestFileText, mockTestFilePath);
+    });
+
+    describe('the get test definitions method', () => {
+      it('should return the correct test definitions for the occurring identical test descriptions', () => {
+        const identicalTestDefinition1 = testDefinitionProvider.getTestDefinitions(
+          ['test suite 1', 'test suite 1-1', 'identical inner suite'],
+          'identical inner test'
+        );
+        const identicalTestDefinition2 = testDefinitionProvider.getTestDefinitions(
+          ['test suite 1', 'test suite 1-2', 'identical inner suite'],
+          'identical inner test'
+        );
+
+        expect(identicalTestDefinition1).toEqual([
+          {
+            test: expect.objectContaining({
+              // 'identical inner test',
+              type: TestType.Test,
+              state: TestDefinitionState.Default,
+              disabled: false,
+              file: mockTestFilePath,
+              line: 4
+            }),
+            suite: expect.arrayContaining([
+              expect.objectContaining({
+                // 'test suite 1',
+                type: TestType.Suite,
+                state: TestDefinitionState.Default,
+                disabled: false,
+                file: mockTestFilePath,
+                line: 1
+              }),
+              expect.objectContaining({
+                // 'test suite 1-1',
+                type: TestType.Suite,
+                state: TestDefinitionState.Default,
+                disabled: false,
+                file: mockTestFilePath,
+                line: 2
+              }),
+              expect.objectContaining({
+                // 'identical inner suite',
+                type: TestType.Suite,
+                state: TestDefinitionState.Default,
+                disabled: false,
+                file: mockTestFilePath,
+                line: 3
+              })
+            ])
+          }
+        ]);
+
+        expect(identicalTestDefinition2).toEqual([
+          {
+            test: expect.objectContaining({
+              // 'identical inner test',
+              type: TestType.Test,
+              state: TestDefinitionState.Default,
+              disabled: false,
+              file: mockTestFilePath,
+              line: 11
+            }),
+            suite: expect.arrayContaining([
+              expect.objectContaining({
+                // 'test suite 1',
+                type: TestType.Suite,
+                state: TestDefinitionState.Default,
+                disabled: false,
+                file: mockTestFilePath,
+                line: 1
+              }),
+              expect.objectContaining({
+                // 'test suite 1-2',
+                type: TestType.Suite,
+                state: TestDefinitionState.Default,
+                disabled: false,
+                file: mockTestFilePath,
+                line: 9
+              }),
+              expect.objectContaining({
+                // 'identical inner suite',
+                type: TestType.Suite,
+                state: TestDefinitionState.Default,
+                disabled: false,
+                file: mockTestFilePath,
+                line: 10
+              })
+            ])
+          }
+        ]);
+      });
+    });
+  });
+});

--- a/test/core/parser/regexp/regexp-test-file-parser.test.ts
+++ b/test/core/parser/regexp/regexp-test-file-parser.test.ts
@@ -1,45 +1,44 @@
 import { mock, MockProxy } from 'jest-mock-extended';
 import { TestDefinitionState } from '../../../../src/core/base/test-definition';
-import { TestNodeType } from '../../../../src/core/base/test-node';
 import { RegexpTestFileParser } from '../../../../src/core/parser/regexp/regexp-test-file-parser';
+import { TestNodeType } from '../../../../src/core/parser/regexp/test-node';
 import { JasmineTestFramework } from '../../../../src/frameworks/jasmine/jasmine-test-framework';
 import { MochaTestFrameworkBdd, MochaTestFrameworkTdd } from '../../../../src/frameworks/mocha/mocha-test-framework';
 import { Logger } from '../../../../src/util/logging/logger';
 import { jasmineInterfaceKeywords, mochaBddInterfaceKeywords, mochaTddInterfaceKeywords } from '../parser-test-utils';
 
 describe('RegexpTestFileParser', () => {
-  let mockLogger: MockProxy<Logger>;
-  let jasmineTestInterface = JasmineTestFramework.getTestInterface();
-  let mochaBddTestInterface = MochaTestFrameworkBdd.getTestInterface();
-  let mochaTddTestInterface = MochaTestFrameworkTdd.getTestInterface();
+  const fakeTestFilePath = '/fake/test/file/path.ts';
 
-  beforeEach(() => {
-    mockLogger = mock<Logger>();
-    jasmineTestInterface = JasmineTestFramework.getTestInterface();
-    mochaBddTestInterface = MochaTestFrameworkBdd.getTestInterface();
-    mochaTddTestInterface = MochaTestFrameworkTdd.getTestInterface();
-  });
-
-  describe.each([
+  const testInterfaceData = [
     {
       testInterfaceName: 'jasmine',
-      testInterface: jasmineTestInterface,
+      testInterface: JasmineTestFramework.getTestInterface(),
       _: jasmineInterfaceKeywords
     },
     {
       testInterfaceName: 'mocha-bdd',
-      testInterface: mochaBddTestInterface,
+      testInterface: MochaTestFrameworkBdd.getTestInterface(),
       _: mochaBddInterfaceKeywords
     },
     {
       testInterfaceName: 'mocha-tdd',
-      testInterface: mochaTddTestInterface,
+      testInterface: MochaTestFrameworkTdd.getTestInterface(),
       _: mochaTddInterfaceKeywords
     }
-  ])('using the $testInterfaceName test interface', ({ testInterface, _ }) => {
-    it('correctly parses single-line comments', () => {
-      const testParser = new RegexpTestFileParser(testInterface, mockLogger);
-      const fileText = `
+  ];
+
+  let mockLogger: MockProxy<Logger>;
+
+  beforeEach(() => {
+    mockLogger = mock<Logger>();
+  });
+
+  testInterfaceData.forEach(({ testInterfaceName, testInterface, _ }) => {
+    describe(`using the ${testInterfaceName} test interface`, () => {
+      it('correctly parses single-line comments', () => {
+        const testParser = new RegexpTestFileParser(testInterface, mockLogger);
+        const fileText = `
         // single-line comment
         ${_.describe}('test suite 1', () => {
           // single-line comment
@@ -54,25 +53,25 @@ describe('RegexpTestFileParser', () => {
         })
         // single-line comment
       `;
-      const testSuiteFileInfo = testParser.parseFileText(fileText);
+        const testSuiteFileInfo = testParser.parseFileText(fileText, fakeTestFilePath);
 
-      expect(testSuiteFileInfo[TestNodeType.Suite]).toEqual([
-        {
-          type: TestNodeType.Suite,
-          description: 'test suite 1',
-          line: 2,
-          state: TestDefinitionState.Default
-        }
-      ]);
-      expect(testSuiteFileInfo[TestNodeType.Test]).toEqual([
-        { type: TestNodeType.Test, description: 'test 1', line: 4, state: TestDefinitionState.Default },
-        { type: TestNodeType.Test, description: 'test 2', line: 9, state: TestDefinitionState.Default }
-      ]);
-    });
+        expect(testSuiteFileInfo[TestNodeType.Suite]).toEqual([
+          {
+            type: TestNodeType.Suite,
+            description: 'test suite 1',
+            line: 2,
+            state: TestDefinitionState.Default
+          }
+        ]);
+        expect(testSuiteFileInfo[TestNodeType.Test]).toEqual([
+          { type: TestNodeType.Test, description: 'test 1', line: 4, state: TestDefinitionState.Default },
+          { type: TestNodeType.Test, description: 'test 2', line: 9, state: TestDefinitionState.Default }
+        ]);
+      });
 
-    it('correctly parses multi-line comments', () => {
-      const testParser = new RegexpTestFileParser(testInterface, mockLogger);
-      const fileText = `
+      it('correctly parses multi-line comments', () => {
+        const testParser = new RegexpTestFileParser(testInterface, mockLogger);
+        const fileText = `
         /* multi-line comment with comment opening
         and closing on same lines as text */
         ${_.describe}('test suite 1', () => {
@@ -89,25 +88,25 @@ describe('RegexpTestFileParser', () => {
           });
         })
       `;
-      const testSuiteFileInfo = testParser.parseFileText(fileText);
+        const testSuiteFileInfo = testParser.parseFileText(fileText, fakeTestFilePath);
 
-      expect(testSuiteFileInfo[TestNodeType.Suite]).toEqual([
-        {
-          type: TestNodeType.Suite,
-          description: 'test suite 1',
-          line: 3,
-          state: TestDefinitionState.Default
-        }
-      ]);
-      expect(testSuiteFileInfo[TestNodeType.Test]).toEqual([
-        { type: TestNodeType.Test, description: 'test 1', line: 8, state: TestDefinitionState.Default },
-        { type: TestNodeType.Test, description: 'test 2', line: 12, state: TestDefinitionState.Default }
-      ]);
-    });
+        expect(testSuiteFileInfo[TestNodeType.Suite]).toEqual([
+          {
+            type: TestNodeType.Suite,
+            description: 'test suite 1',
+            line: 3,
+            state: TestDefinitionState.Default
+          }
+        ]);
+        expect(testSuiteFileInfo[TestNodeType.Test]).toEqual([
+          { type: TestNodeType.Test, description: 'test 1', line: 8, state: TestDefinitionState.Default },
+          { type: TestNodeType.Test, description: 'test 2', line: 12, state: TestDefinitionState.Default }
+        ]);
+      });
 
-    it('correctly parses commented out tests', () => {
-      const testParser = new RegexpTestFileParser(testInterface, mockLogger);
-      const fileText = `
+      it('correctly parses commented out tests', () => {
+        const testParser = new RegexpTestFileParser(testInterface, mockLogger);
+        const fileText = `
         ${_.describe}('test suite 1', () => {
           /*
           ${_.it}('commented out test 1') {
@@ -121,24 +120,24 @@ describe('RegexpTestFileParser', () => {
           });
         })
       `;
-      const testSuiteFileInfo = testParser.parseFileText(fileText);
+        const testSuiteFileInfo = testParser.parseFileText(fileText, fakeTestFilePath);
 
-      expect(testSuiteFileInfo[TestNodeType.Suite]).toEqual([
-        {
-          type: TestNodeType.Suite,
-          description: 'test suite 1',
-          line: 1,
-          state: TestDefinitionState.Default
-        }
-      ]);
-      expect(testSuiteFileInfo[TestNodeType.Test]).toEqual([
-        { type: TestNodeType.Test, description: 'test 1', line: 7, state: TestDefinitionState.Default }
-      ]);
-    });
+        expect(testSuiteFileInfo[TestNodeType.Suite]).toEqual([
+          {
+            type: TestNodeType.Suite,
+            description: 'test suite 1',
+            line: 1,
+            state: TestDefinitionState.Default
+          }
+        ]);
+        expect(testSuiteFileInfo[TestNodeType.Test]).toEqual([
+          { type: TestNodeType.Test, description: 'test 1', line: 7, state: TestDefinitionState.Default }
+        ]);
+      });
 
-    it('correctly parses a combination of various kinds of comments in the same file', () => {
-      const testParser = new RegexpTestFileParser(testInterface, mockLogger);
-      const fileText = `
+      it('correctly parses a combination of various kinds of comments in the same file', () => {
+        const testParser = new RegexpTestFileParser(testInterface, mockLogger);
+        const fileText = `
         ${_.describe}('test suite 1', () => {
           ${_.it}('test 1', () => {
             // single-line comments
@@ -154,48 +153,48 @@ describe('RegexpTestFileParser', () => {
           */
         })
       `;
-      const testSuiteFileInfo = testParser.parseFileText(fileText);
+        const testSuiteFileInfo = testParser.parseFileText(fileText, fakeTestFilePath);
 
-      expect(testSuiteFileInfo[TestNodeType.Suite]).toEqual([
-        {
-          type: TestNodeType.Suite,
-          description: 'test suite 1',
-          line: 1,
-          state: TestDefinitionState.Default
-        }
-      ]);
-      expect(testSuiteFileInfo[TestNodeType.Test]).toEqual([
-        { type: TestNodeType.Test, description: 'test 1', line: 2, state: TestDefinitionState.Default }
-      ]);
-    });
+        expect(testSuiteFileInfo[TestNodeType.Suite]).toEqual([
+          {
+            type: TestNodeType.Suite,
+            description: 'test suite 1',
+            line: 1,
+            state: TestDefinitionState.Default
+          }
+        ]);
+        expect(testSuiteFileInfo[TestNodeType.Test]).toEqual([
+          { type: TestNodeType.Test, description: 'test 1', line: 2, state: TestDefinitionState.Default }
+        ]);
+      });
 
-    it('correctly parses non-arrow function tests', () => {
-      const testParser = new RegexpTestFileParser(testInterface, mockLogger);
-      const fileText = `
+      it('correctly parses non-arrow function tests', () => {
+        const testParser = new RegexpTestFileParser(testInterface, mockLogger);
+        const fileText = `
         ${_.describe}('test suite 1', function() {
           ${_.it}('test 1', function() {
             // test contents
           });
         })
       `;
-      const testSuiteFileInfo = testParser.parseFileText(fileText);
+        const testSuiteFileInfo = testParser.parseFileText(fileText, fakeTestFilePath);
 
-      expect(testSuiteFileInfo[TestNodeType.Suite]).toEqual([
-        {
-          type: TestNodeType.Suite,
-          description: 'test suite 1',
-          line: 1,
-          state: TestDefinitionState.Default
-        }
-      ]);
-      expect(testSuiteFileInfo[TestNodeType.Test]).toEqual([
-        { type: TestNodeType.Test, description: 'test 1', line: 2, state: TestDefinitionState.Default }
-      ]);
-    });
+        expect(testSuiteFileInfo[TestNodeType.Suite]).toEqual([
+          {
+            type: TestNodeType.Suite,
+            description: 'test suite 1',
+            line: 1,
+            state: TestDefinitionState.Default
+          }
+        ]);
+        expect(testSuiteFileInfo[TestNodeType.Test]).toEqual([
+          { type: TestNodeType.Test, description: 'test 1', line: 2, state: TestDefinitionState.Default }
+        ]);
+      });
 
-    it('correctly parses tests with description on following line', () => {
-      const testParser = new RegexpTestFileParser(testInterface, mockLogger);
-      const fileText = `
+      it('correctly parses tests with description on following line', () => {
+        const testParser = new RegexpTestFileParser(testInterface, mockLogger);
+        const fileText = `
         ${_.describe}(
           'test suite 1', function() {
           ${_.it}(
@@ -204,122 +203,122 @@ describe('RegexpTestFileParser', () => {
           });
         })
       `;
-      const testSuiteFileInfo = testParser.parseFileText(fileText);
+        const testSuiteFileInfo = testParser.parseFileText(fileText, fakeTestFilePath);
 
-      expect(testSuiteFileInfo[TestNodeType.Suite]).toEqual([
-        {
-          type: TestNodeType.Suite,
-          description: 'test suite 1',
-          line: 1,
-          state: TestDefinitionState.Default
-        }
-      ]);
-      expect(testSuiteFileInfo[TestNodeType.Test]).toEqual([
-        {
-          type: TestNodeType.Test,
-          description: 'test 1',
-          line: 3,
-          state: TestDefinitionState.Default
-        }
-      ]);
-    });
+        expect(testSuiteFileInfo[TestNodeType.Suite]).toEqual([
+          {
+            type: TestNodeType.Suite,
+            description: 'test suite 1',
+            line: 1,
+            state: TestDefinitionState.Default
+          }
+        ]);
+        expect(testSuiteFileInfo[TestNodeType.Test]).toEqual([
+          {
+            type: TestNodeType.Test,
+            description: 'test 1',
+            line: 3,
+            state: TestDefinitionState.Default
+          }
+        ]);
+      });
 
-    it('correctly parses test description containing curly brace', () => {
-      const testParser = new RegexpTestFileParser(testInterface, mockLogger);
-      const fileText = `
+      it('correctly parses test description containing curly brace', () => {
+        const testParser = new RegexpTestFileParser(testInterface, mockLogger);
+        const fileText = `
         ${_.describe}('test { suite 1', function() {
           ${_.it}('test } 1', function() {
             // test contents
           });
         })
       `;
-      const testSuiteFileInfo = testParser.parseFileText(fileText);
+        const testSuiteFileInfo = testParser.parseFileText(fileText, fakeTestFilePath);
 
-      expect(testSuiteFileInfo[TestNodeType.Suite]).toEqual([
-        {
-          type: TestNodeType.Suite,
-          description: 'test { suite 1',
-          line: 1,
-          state: TestDefinitionState.Default
-        }
-      ]);
-      expect(testSuiteFileInfo[TestNodeType.Test]).toEqual([
-        { type: TestNodeType.Test, description: 'test } 1', line: 2, state: TestDefinitionState.Default }
-      ]);
-    });
+        expect(testSuiteFileInfo[TestNodeType.Suite]).toEqual([
+          {
+            type: TestNodeType.Suite,
+            description: 'test { suite 1',
+            line: 1,
+            state: TestDefinitionState.Default
+          }
+        ]);
+        expect(testSuiteFileInfo[TestNodeType.Test]).toEqual([
+          { type: TestNodeType.Test, description: 'test } 1', line: 2, state: TestDefinitionState.Default }
+        ]);
+      });
 
-    it('correctly parses test description containing parentheses', () => {
-      const testParser = new RegexpTestFileParser(testInterface, mockLogger);
-      const fileText = `
+      it('correctly parses test description containing parentheses', () => {
+        const testParser = new RegexpTestFileParser(testInterface, mockLogger);
+        const fileText = `
         ${_.describe}('test ( suite 1', function() {
           ${_.it}('test ) 1', function() {
             // test contents
           });
         })
       `;
-      const testSuiteFileInfo = testParser.parseFileText(fileText);
+        const testSuiteFileInfo = testParser.parseFileText(fileText, fakeTestFilePath);
 
-      expect(testSuiteFileInfo[TestNodeType.Suite]).toEqual([
-        {
-          type: TestNodeType.Suite,
-          description: 'test ( suite 1',
-          line: 1,
-          state: TestDefinitionState.Default
-        }
-      ]);
-      expect(testSuiteFileInfo[TestNodeType.Test]).toEqual([
-        { type: TestNodeType.Test, description: 'test ) 1', line: 2, state: TestDefinitionState.Default }
-      ]);
-    });
+        expect(testSuiteFileInfo[TestNodeType.Suite]).toEqual([
+          {
+            type: TestNodeType.Suite,
+            description: 'test ( suite 1',
+            line: 1,
+            state: TestDefinitionState.Default
+          }
+        ]);
+        expect(testSuiteFileInfo[TestNodeType.Test]).toEqual([
+          { type: TestNodeType.Test, description: 'test ) 1', line: 2, state: TestDefinitionState.Default }
+        ]);
+      });
 
-    it('correctly parses single-line test format', () => {
-      const testParser = new RegexpTestFileParser(testInterface, mockLogger);
-      const fileText = `
+      it('correctly parses single-line test format', () => {
+        const testParser = new RegexpTestFileParser(testInterface, mockLogger);
+        const fileText = `
         ${_.describe}('test suite 1', () => {
           ${_.it}('test 1', () => { /* test contents */ });
         })
       `;
-      const testSuiteFileInfo = testParser.parseFileText(fileText);
+        const testSuiteFileInfo = testParser.parseFileText(fileText, fakeTestFilePath);
 
-      expect(testSuiteFileInfo[TestNodeType.Suite]).toEqual([
-        {
-          type: TestNodeType.Suite,
-          description: 'test suite 1',
-          line: 1,
-          state: TestDefinitionState.Default
-        }
-      ]);
-      expect(testSuiteFileInfo[TestNodeType.Test]).toEqual([
-        { type: TestNodeType.Test, description: 'test 1', line: 2, state: TestDefinitionState.Default }
-      ]);
-    });
+        expect(testSuiteFileInfo[TestNodeType.Suite]).toEqual([
+          {
+            type: TestNodeType.Suite,
+            description: 'test suite 1',
+            line: 1,
+            state: TestDefinitionState.Default
+          }
+        ]);
+        expect(testSuiteFileInfo[TestNodeType.Test]).toEqual([
+          { type: TestNodeType.Test, description: 'test 1', line: 2, state: TestDefinitionState.Default }
+        ]);
+      });
 
-    it('correctly parses tests defined starting on the first line of the file', () => {
-      const testParser = new RegexpTestFileParser(testInterface, mockLogger);
-      const fileText =
-        // First line begins below
-        `${_.describe}('test suite 1', () => {
+      it('correctly parses tests defined starting on the first line of the file', () => {
+        const testParser = new RegexpTestFileParser(testInterface, mockLogger);
+        const fileText =
+          // First line begins below
+          `${_.describe}('test suite 1', () => {
           ${_.it}('test 1', () => { /* test contents */ });
         })
       `;
-      const testSuiteFileInfo = testParser.parseFileText(fileText);
+        const testSuiteFileInfo = testParser.parseFileText(fileText, fakeTestFilePath);
 
-      expect(testSuiteFileInfo[TestNodeType.Suite]).toEqual([
-        {
-          type: TestNodeType.Suite,
-          description: 'test suite 1',
-          line: 0,
-          state: TestDefinitionState.Default
-        }
-      ]);
-      expect(testSuiteFileInfo[TestNodeType.Test]).toEqual([
-        { type: TestNodeType.Test, description: 'test 1', line: 1, state: TestDefinitionState.Default }
-      ]);
-    });
+        expect(testSuiteFileInfo[TestNodeType.Suite]).toEqual([
+          {
+            type: TestNodeType.Suite,
+            description: 'test suite 1',
+            line: 0,
+            state: TestDefinitionState.Default
+          }
+        ]);
+        expect(testSuiteFileInfo[TestNodeType.Test]).toEqual([
+          { type: TestNodeType.Test, description: 'test 1', line: 1, state: TestDefinitionState.Default }
+        ]);
+      });
 
-    it('correctly parses nested test suites with no identical test descriptions', () => {
-      const testParser = new RegexpTestFileParser(testInterface, mockLogger);
-      const fileText = `
+      it('correctly parses nested test suites with no identical test descriptions', () => {
+        const testParser = new RegexpTestFileParser(testInterface, mockLogger);
+        const fileText = `
         ${_.describe}('test suite 1', () => {
           ${_.describe}('test suite 2', () => {
             ${_.describe}('test suite 3', () => {
@@ -331,36 +330,36 @@ describe('RegexpTestFileParser', () => {
         });
       `;
 
-      const testSuiteFileInfo = testParser.parseFileText(fileText);
+        const testSuiteFileInfo = testParser.parseFileText(fileText, fakeTestFilePath);
 
-      expect(testSuiteFileInfo[TestNodeType.Suite]).toEqual([
-        {
-          type: TestNodeType.Suite,
-          description: 'test suite 1',
-          line: 1,
-          state: TestDefinitionState.Default
-        },
-        {
-          type: TestNodeType.Suite,
-          description: 'test suite 2',
-          line: 2,
-          state: TestDefinitionState.Default
-        },
-        {
-          type: TestNodeType.Suite,
-          description: 'test suite 3',
-          line: 3,
-          state: TestDefinitionState.Default
-        }
-      ]);
-      expect(testSuiteFileInfo[TestNodeType.Test]).toEqual([
-        { type: TestNodeType.Test, description: 'test 1', line: 4, state: TestDefinitionState.Default }
-      ]);
-    });
+        expect(testSuiteFileInfo[TestNodeType.Suite]).toEqual([
+          {
+            type: TestNodeType.Suite,
+            description: 'test suite 1',
+            line: 1,
+            state: TestDefinitionState.Default
+          },
+          {
+            type: TestNodeType.Suite,
+            description: 'test suite 2',
+            line: 2,
+            state: TestDefinitionState.Default
+          },
+          {
+            type: TestNodeType.Suite,
+            description: 'test suite 3',
+            line: 3,
+            state: TestDefinitionState.Default
+          }
+        ]);
+        expect(testSuiteFileInfo[TestNodeType.Test]).toEqual([
+          { type: TestNodeType.Test, description: 'test 1', line: 4, state: TestDefinitionState.Default }
+        ]);
+      });
 
-    it('correctly parses nested test suites with one or more identical test descriptions', () => {
-      const testParser = new RegexpTestFileParser(testInterface, mockLogger);
-      const fileText = `
+      it('correctly parses nested test suites with one or more identical test descriptions', () => {
+        const testParser = new RegexpTestFileParser(testInterface, mockLogger);
+        const fileText = `
         ${_.describe}('test suite 1', function () {
           ${_.describe}('test suite 1-1', function () {
             ${_.describe}('identical inner suite', function () {
@@ -379,59 +378,59 @@ describe('RegexpTestFileParser', () => {
         })
       `;
 
-      const testSuiteFileInfo = testParser.parseFileText(fileText);
+        const testSuiteFileInfo = testParser.parseFileText(fileText, fakeTestFilePath);
 
-      expect(testSuiteFileInfo[TestNodeType.Suite]).toEqual([
-        {
-          type: TestNodeType.Suite,
-          description: 'test suite 1',
-          line: 1,
-          state: TestDefinitionState.Default
-        },
-        {
-          type: TestNodeType.Suite,
-          description: 'test suite 1-1',
-          line: 2,
-          state: TestDefinitionState.Default
-        },
-        {
-          type: TestNodeType.Suite,
-          description: 'identical inner suite',
-          line: 3,
-          state: TestDefinitionState.Default
-        },
-        {
-          type: TestNodeType.Suite,
-          description: 'test suite 1-2',
-          line: 9,
-          state: TestDefinitionState.Default
-        },
-        {
-          type: TestNodeType.Suite,
-          description: 'identical inner suite',
-          line: 10,
-          state: TestDefinitionState.Default
-        }
-      ]);
-      expect(testSuiteFileInfo[TestNodeType.Test]).toEqual([
-        {
-          type: TestNodeType.Test,
-          description: 'identical inner test',
-          line: 4,
-          state: TestDefinitionState.Default
-        },
-        {
-          type: TestNodeType.Test,
-          description: 'identical inner test',
-          line: 11,
-          state: TestDefinitionState.Default
-        }
-      ]);
-    });
+        expect(testSuiteFileInfo[TestNodeType.Suite]).toEqual([
+          {
+            type: TestNodeType.Suite,
+            description: 'test suite 1',
+            line: 1,
+            state: TestDefinitionState.Default
+          },
+          {
+            type: TestNodeType.Suite,
+            description: 'test suite 1-1',
+            line: 2,
+            state: TestDefinitionState.Default
+          },
+          {
+            type: TestNodeType.Suite,
+            description: 'identical inner suite',
+            line: 3,
+            state: TestDefinitionState.Default
+          },
+          {
+            type: TestNodeType.Suite,
+            description: 'test suite 1-2',
+            line: 9,
+            state: TestDefinitionState.Default
+          },
+          {
+            type: TestNodeType.Suite,
+            description: 'identical inner suite',
+            line: 10,
+            state: TestDefinitionState.Default
+          }
+        ]);
+        expect(testSuiteFileInfo[TestNodeType.Test]).toEqual([
+          {
+            type: TestNodeType.Test,
+            description: 'identical inner test',
+            line: 4,
+            state: TestDefinitionState.Default
+          },
+          {
+            type: TestNodeType.Test,
+            description: 'identical inner test',
+            line: 11,
+            state: TestDefinitionState.Default
+          }
+        ]);
+      });
 
-    it('correctly parses file with multiple top level suites', () => {
-      const testParser = new RegexpTestFileParser(testInterface, mockLogger);
-      const fileText = `
+      it('correctly parses file with multiple top level suites', () => {
+        const testParser = new RegexpTestFileParser(testInterface, mockLogger);
+        const fileText = `
         ${_.describe}('test suite 1', {
           ${_.it}('test 1', () => {
             // test contents
@@ -444,122 +443,123 @@ describe('RegexpTestFileParser', () => {
         });
       `;
 
-      const testSuiteFileInfo = testParser.parseFileText(fileText);
+        const testSuiteFileInfo = testParser.parseFileText(fileText, fakeTestFilePath);
 
-      expect(testSuiteFileInfo[TestNodeType.Suite]).toEqual([
-        {
-          type: TestNodeType.Suite,
-          description: 'test suite 1',
-          line: 1,
-          state: TestDefinitionState.Default
-        },
-        {
-          type: TestNodeType.Suite,
-          description: 'test suite 2',
-          line: 6,
-          state: TestDefinitionState.Default
-        }
-      ]);
-      expect(testSuiteFileInfo[TestNodeType.Test]).toEqual([
-        { type: TestNodeType.Test, description: 'test 1', line: 2, state: TestDefinitionState.Default },
-        { type: TestNodeType.Test, description: 'test 2', line: 7, state: TestDefinitionState.Default }
-      ]);
-    });
+        expect(testSuiteFileInfo[TestNodeType.Suite]).toEqual([
+          {
+            type: TestNodeType.Suite,
+            description: 'test suite 1',
+            line: 1,
+            state: TestDefinitionState.Default
+          },
+          {
+            type: TestNodeType.Suite,
+            description: 'test suite 2',
+            line: 6,
+            state: TestDefinitionState.Default
+          }
+        ]);
+        expect(testSuiteFileInfo[TestNodeType.Test]).toEqual([
+          { type: TestNodeType.Test, description: 'test 1', line: 2, state: TestDefinitionState.Default },
+          { type: TestNodeType.Test, description: 'test 2', line: 7, state: TestDefinitionState.Default }
+        ]);
+      });
 
-    it('correctly parses focused suites', () => {
-      const testParser = new RegexpTestFileParser(testInterface, mockLogger);
-      const fileText = `
+      it('correctly parses focused suites', () => {
+        const testParser = new RegexpTestFileParser(testInterface, mockLogger);
+        const fileText = `
         ${_.fdescribe}('test suite 1', () => {
           ${_.it}('test 1', () => {
             // test contents
           });
         })
       `;
-      const testSuiteFileInfo = testParser.parseFileText(fileText);
+        const testSuiteFileInfo = testParser.parseFileText(fileText, fakeTestFilePath);
 
-      expect(testSuiteFileInfo[TestNodeType.Suite]).toEqual([
-        {
-          type: TestNodeType.Suite,
-          description: 'test suite 1',
-          line: 1,
-          state: TestDefinitionState.Focused
-        }
-      ]);
-      expect(testSuiteFileInfo[TestNodeType.Test]).toEqual([
-        { type: TestNodeType.Test, description: 'test 1', line: 2, state: TestDefinitionState.Default }
-      ]);
-    });
+        expect(testSuiteFileInfo[TestNodeType.Suite]).toEqual([
+          {
+            type: TestNodeType.Suite,
+            description: 'test suite 1',
+            line: 1,
+            state: TestDefinitionState.Focused
+          }
+        ]);
+        expect(testSuiteFileInfo[TestNodeType.Test]).toEqual([
+          { type: TestNodeType.Test, description: 'test 1', line: 2, state: TestDefinitionState.Default }
+        ]);
+      });
 
-    it('correctly parses focused tests', () => {
-      const testParser = new RegexpTestFileParser(testInterface, mockLogger);
-      const fileText = `
+      it('correctly parses focused tests', () => {
+        const testParser = new RegexpTestFileParser(testInterface, mockLogger);
+        const fileText = `
         ${_.describe}('test suite 1', () => {
           ${_.fit}('test 1', () => {
             // test contents
           });
         })
       `;
-      const testSuiteFileInfo = testParser.parseFileText(fileText);
+        const testSuiteFileInfo = testParser.parseFileText(fileText, fakeTestFilePath);
 
-      expect(testSuiteFileInfo[TestNodeType.Suite]).toEqual([
-        {
-          type: TestNodeType.Suite,
-          description: 'test suite 1',
-          line: 1,
-          state: TestDefinitionState.Default
-        }
-      ]);
-      expect(testSuiteFileInfo[TestNodeType.Test]).toEqual([
-        { type: TestNodeType.Test, description: 'test 1', line: 2, state: TestDefinitionState.Focused }
-      ]);
-    });
+        expect(testSuiteFileInfo[TestNodeType.Suite]).toEqual([
+          {
+            type: TestNodeType.Suite,
+            description: 'test suite 1',
+            line: 1,
+            state: TestDefinitionState.Default
+          }
+        ]);
+        expect(testSuiteFileInfo[TestNodeType.Test]).toEqual([
+          { type: TestNodeType.Test, description: 'test 1', line: 2, state: TestDefinitionState.Focused }
+        ]);
+      });
 
-    it('correctly parses disabled suites', () => {
-      const testParser = new RegexpTestFileParser(testInterface, mockLogger);
-      const fileText = `
+      it('correctly parses disabled suites', () => {
+        const testParser = new RegexpTestFileParser(testInterface, mockLogger);
+        const fileText = `
         ${_.xdescribe}('test suite 1', () => {
           ${_.it}('test 1', () => {
             // test contents
           });
         })
       `;
-      const testSuiteFileInfo = testParser.parseFileText(fileText);
+        const testSuiteFileInfo = testParser.parseFileText(fileText, fakeTestFilePath);
 
-      expect(testSuiteFileInfo[TestNodeType.Suite]).toEqual([
-        {
-          type: TestNodeType.Suite,
-          description: 'test suite 1',
-          line: 1,
-          state: TestDefinitionState.Disabled
-        }
-      ]);
-      expect(testSuiteFileInfo[TestNodeType.Test]).toEqual([
-        { type: TestNodeType.Test, description: 'test 1', line: 2, state: TestDefinitionState.Default }
-      ]);
-    });
+        expect(testSuiteFileInfo[TestNodeType.Suite]).toEqual([
+          {
+            type: TestNodeType.Suite,
+            description: 'test suite 1',
+            line: 1,
+            state: TestDefinitionState.Disabled
+          }
+        ]);
+        expect(testSuiteFileInfo[TestNodeType.Test]).toEqual([
+          { type: TestNodeType.Test, description: 'test 1', line: 2, state: TestDefinitionState.Default }
+        ]);
+      });
 
-    it('correctly parses disabled tests', () => {
-      const testParser = new RegexpTestFileParser(testInterface, mockLogger);
-      const fileText = `
+      it('correctly parses disabled tests', () => {
+        const testParser = new RegexpTestFileParser(testInterface, mockLogger);
+        const fileText = `
         ${_.describe}('test suite 1', () => {
           ${_.xit}('test 1', () => {
             // test contents
           });
         })
       `;
-      const testSuiteFileInfo = testParser.parseFileText(fileText);
+        const testSuiteFileInfo = testParser.parseFileText(fileText, fakeTestFilePath);
 
-      expect(testSuiteFileInfo[TestNodeType.Suite]).toEqual([
-        {
-          type: TestNodeType.Suite,
-          description: 'test suite 1',
-          line: 1,
-          state: TestDefinitionState.Default
-        }
-      ]);
-      expect(testSuiteFileInfo[TestNodeType.Test]).toEqual([
-        { type: TestNodeType.Test, description: 'test 1', line: 2, state: TestDefinitionState.Disabled }
-      ]);
+        expect(testSuiteFileInfo[TestNodeType.Suite]).toEqual([
+          {
+            type: TestNodeType.Suite,
+            description: 'test suite 1',
+            line: 1,
+            state: TestDefinitionState.Default
+          }
+        ]);
+        expect(testSuiteFileInfo[TestNodeType.Test]).toEqual([
+          { type: TestNodeType.Test, description: 'test 1', line: 2, state: TestDefinitionState.Disabled }
+        ]);
+      });
     });
   });
 });

--- a/test/core/test-locator.test.ts
+++ b/test/core/test-locator.test.ts
@@ -1,10 +1,5 @@
 import { mock, MockProxy } from 'jest-mock-extended';
-import { TestDefinitionState } from '../../src/core/base/test-definition';
 import { TestDefinitionProvider } from '../../src/core/base/test-definition-provider';
-import { TestType } from '../../src/core/base/test-infos';
-import { TestNodeType } from '../../src/core/base/test-node';
-import { RegexpTestDefinitionProvider } from '../../src/core/parser/regexp/regexp-test-definition-provider';
-import { RegexpTestFileParser, RegexpTestFileParserResult } from '../../src/core/parser/regexp/regexp-test-file-parser';
 import { TestLocator } from '../../src/core/test-locator';
 import { FileHandler } from '../../src/util/file-handler';
 import { Logger } from '../../src/util/logging/logger';
@@ -13,237 +8,94 @@ import { withUnixStyleSeparator } from '../test-util';
 type FilePathTestData = { filePathStyle: string; mockTestFiles: string[] }[];
 type FileGlobTestData = { globPathStyle: string; mockFileGlobs: string[] }[];
 
+// --- Test Data ---
+
+const windowsBackSlashTestFiles = ['D:\\test\\path\\abc.test.ts', 'd:\\test\\path\\def.test.ts'];
+const windowsForwardSlashTestFiles = ['D:/test/path/abc.test.ts', 'd:/test/path/def.test.ts'];
+const unixStyleTestFiles = ['/test/path/abc.test.ts', '/test/path/def.test.ts'];
+
+const windowsBackSlashFileGlobs = ['**\\*.test.ts'];
+const unixStyleFileGlobs = ['**/*.test.ts'];
+
+const windowsPathsTestData: FilePathTestData = [
+  { filePathStyle: 'Windows back slash', mockTestFiles: windowsBackSlashTestFiles },
+  { filePathStyle: 'Windows forward slash', mockTestFiles: windowsForwardSlashTestFiles }
+];
+const unixPathsTestData: FilePathTestData = [{ filePathStyle: 'Unix', mockTestFiles: unixStyleTestFiles }];
+
+const filePathTestData = process.platform === 'win32' ? windowsPathsTestData : unixPathsTestData;
+
+const fileGlobTestData: FileGlobTestData =
+  process.platform === 'win32'
+    ? [{ globPathStyle: 'Windows back slash', mockFileGlobs: windowsBackSlashFileGlobs }]
+    : [{ globPathStyle: 'Unix', mockFileGlobs: unixStyleFileGlobs }];
+
+// --- Tests ---
+
 describe('TestLocator', () => {
-  const windowsBackSlashTestFiles = ['D:\\test\\path\\abc.test.ts', 'd:\\test\\path\\def.test.ts'];
-  const windowsForwardSlashTestFiles = ['D:/test/path/abc.test.ts', 'd:/test/path/def.test.ts'];
-  const unixStyleTestFiles = ['/test/path/abc.test.ts', '/test/path/def.test.ts'];
-
-  const windowsBackSlashFileGlobs = ['**\\*.test.ts'];
-  const unixStyleFileGlobs = ['**/*.test.ts'];
-
-  const windowsPathsTestData: FilePathTestData = [
-    { filePathStyle: 'Windows back slash', mockTestFiles: windowsBackSlashTestFiles },
-    { filePathStyle: 'Windows forward slash', mockTestFiles: windowsForwardSlashTestFiles }
-  ];
-  const unixPathsTestData: FilePathTestData = [{ filePathStyle: 'Unix', mockTestFiles: unixStyleTestFiles }];
-  const filePathTestData = process.platform === 'win32' ? windowsPathsTestData : unixPathsTestData;
-
-  const fileGlobTestData: FileGlobTestData =
-    process.platform === 'win32'
-      ? [{ globPathStyle: 'Windows back slash', mockFileGlobs: windowsBackSlashFileGlobs }]
-      : [{ globPathStyle: 'Unix', mockFileGlobs: unixStyleFileGlobs }];
-
-  let mockTestFileParser: MockProxy<RegexpTestFileParser>;
-  let testDefinitionProvider: TestDefinitionProvider;
+  let mockFileContent: string;
+  let mockResolvedGlobFiles: string[];
+  let testDefinitionProvider: MockProxy<TestDefinitionProvider>;
   let mockFileHandler: MockProxy<FileHandler>;
   let mockLogger: MockProxy<Logger>;
-  let mockResolvedGlobFiles: string[];
 
   beforeEach(() => {
+    mockFileContent = '';
     mockResolvedGlobFiles = [];
-    mockLogger = mock<Logger>();
     mockFileHandler = mock<FileHandler>();
     mockFileHandler.resolveFileGlobs.mockImplementation(() => Promise.resolve(mockResolvedGlobFiles));
-    mockTestFileParser = mock<RegexpTestFileParser>();
-    testDefinitionProvider = new RegexpTestDefinitionProvider(mockTestFileParser, mockLogger);
+    mockFileHandler.readFile.mockImplementation(() => Promise.resolve(mockFileContent));
 
-    mockTestFileParser.parseFileText.mockReturnValue(<RegexpTestFileParserResult>{
-      Suite: [{ type: TestNodeType.Suite, description: 'SuiteName', line: 1, state: TestDefinitionState.Default }],
-      Test: [{ type: TestNodeType.Test, description: 'TestName', line: 2, state: TestDefinitionState.Default }]
-    });
+    mockLogger = mock<Logger>();
+    testDefinitionProvider = mock<TestDefinitionProvider>();
+    testDefinitionProvider.getTestDefinitions.mockReturnValue([]);
   });
 
-  describe.each(filePathTestData)('using $filePathStyle style paths', ({ mockTestFiles }) => {
-    beforeEach(() => {
-      mockResolvedGlobFiles = mockTestFiles;
-    });
-
-    describe.each(fileGlobTestData)('and $globPathStyle style globs', ({ mockFileGlobs }) => {
-      let testLocator: TestLocator;
-
-      beforeEach(async () => {
-        testLocator = new TestLocator('/', mockFileGlobs, testDefinitionProvider, mockFileHandler, mockLogger);
-        await testLocator.refreshFiles();
+  filePathTestData.forEach(({ filePathStyle, mockTestFiles }) => {
+    describe(`using ${filePathStyle} style paths`, () => {
+      beforeEach(() => {
+        mockResolvedGlobFiles = mockTestFiles;
+        mockFileContent = 'some fake content';
       });
 
-      describe('the get test definitions method', () => {
-        it('should return the test definitions with normalized file paths', () => {
-          const testDefinitions = testLocator.getTestDefinitions(['SuiteName'], 'TestName');
+      fileGlobTestData.forEach(({ globPathStyle, mockFileGlobs }) => {
+        describe(`and ${globPathStyle} style globs,`, () => {
+          describe(`a new instance`, () => {
+            let testLocator: TestLocator;
 
-          const expectedNormalizedTestFiles = [
-            withUnixStyleSeparator(mockTestFiles[0]).replace(/^d:/, 'D:'),
-            withUnixStyleSeparator(mockTestFiles[1]).replace(/^d:/, 'D:')
-          ];
+            beforeEach(async () => {
+              testLocator = new TestLocator('/', mockFileGlobs, testDefinitionProvider, mockFileHandler, mockLogger);
+              await testLocator.refreshFiles();
+            });
 
-          expect(testDefinitions).toEqual([
-            expect.objectContaining({
-              test: expect.objectContaining({ file: expectedNormalizedTestFiles[0] })
-            }),
-            expect.objectContaining({
-              test: expect.objectContaining({ file: expectedNormalizedTestFiles[1] })
-            })
-          ]);
-        });
-      });
+            it('should process test content using the normalized file paths', () => {
+              const expectedNormalizedTestFiles = [
+                withUnixStyleSeparator(mockTestFiles[0]).replace(/^d:/, 'D:'),
+                withUnixStyleSeparator(mockTestFiles[1]).replace(/^d:/, 'D:')
+              ];
 
-      describe('isTestFile method', () => {
-        it('should return true for files matching the designated test file patterns', () => {
-          const result = testLocator.isTestFile('test/abc.test.ts');
-          expect(result).toBe(true);
-        });
+              expect(testDefinitionProvider.addFileContent).toHaveBeenCalledWith(
+                mockFileContent,
+                expectedNormalizedTestFiles[0]
+              );
 
-        it('should return false for files not matching the designated test file patterns', () => {
-          const result = testLocator.isTestFile('abc-spec.js');
-          expect(result).toBe(false);
-        });
-      });
+              expect(testDefinitionProvider.addFileContent).toHaveBeenCalledWith(
+                mockFileContent,
+                expectedNormalizedTestFiles[1]
+              );
+            });
 
-      describe('and using more complex test file content with nesting and some identical descriptions', () => {
-        const mockTestFilePath = 'path/to/random/test/file';
+            describe('isTestFile method', () => {
+              it('should return true for files matching the designated test file patterns', () => {
+                const result = testLocator.isTestFile('test/abc.test.ts');
+                expect(result).toBe(true);
+              });
 
-        beforeEach(async () => {
-          mockTestFileParser.parseFileText.mockReturnValue(<RegexpTestFileParserResult>{
-            Suite: [
-              {
-                type: TestNodeType.Suite,
-                description: 'test suite 1',
-                line: 1,
-                state: TestDefinitionState.Default
-              },
-              {
-                type: TestNodeType.Suite,
-                description: 'test suite 1-1',
-                line: 2,
-                state: TestDefinitionState.Default
-              },
-              {
-                type: TestNodeType.Suite,
-                description: 'identical inner suite',
-                line: 3,
-                state: TestDefinitionState.Default
-              },
-              {
-                type: TestNodeType.Suite,
-                description: 'test suite 1-2',
-                line: 9,
-                state: TestDefinitionState.Default
-              },
-              {
-                type: TestNodeType.Suite,
-                description: 'identical inner suite',
-                line: 10,
-                state: TestDefinitionState.Default
-              }
-            ],
-            Test: [
-              {
-                type: TestNodeType.Test,
-                description: 'identical inner test',
-                line: 4,
-                state: TestDefinitionState.Default
-              },
-              {
-                type: TestNodeType.Test,
-                description: 'identical inner test',
-                line: 11,
-                state: TestDefinitionState.Default
-              }
-            ]
-          });
-
-          mockResolvedGlobFiles = [mockTestFilePath];
-          testLocator = new TestLocator('/', mockFileGlobs, testDefinitionProvider, mockFileHandler, mockLogger);
-          await testLocator.refreshFiles();
-        });
-
-        describe('the get test definitions method', () => {
-          it('should return the correct test definitions for the occurring identical test descriptions', () => {
-            const identicalTestDefinition1 = testLocator.getTestDefinitions(
-              ['test suite 1', 'test suite 1-1', 'identical inner suite'],
-              'identical inner test'
-            );
-            const identicalTestDefinition2 = testLocator.getTestDefinitions(
-              ['test suite 1', 'test suite 1-2', 'identical inner suite'],
-              'identical inner test'
-            );
-
-            expect(identicalTestDefinition1).toEqual([
-              {
-                test: {
-                  description: 'identical inner test',
-                  type: TestType.Test,
-                  state: TestDefinitionState.Default,
-                  disabled: false,
-                  file: mockTestFilePath,
-                  line: 4
-                },
-                suite: [
-                  {
-                    description: 'test suite 1',
-                    type: TestType.Suite,
-                    state: TestDefinitionState.Default,
-                    disabled: false,
-                    file: mockTestFilePath,
-                    line: 1
-                  },
-                  {
-                    description: 'test suite 1-1',
-                    type: TestType.Suite,
-                    state: TestDefinitionState.Default,
-                    disabled: false,
-                    file: mockTestFilePath,
-                    line: 2
-                  },
-                  {
-                    description: 'identical inner suite',
-                    type: TestType.Suite,
-                    state: TestDefinitionState.Default,
-                    disabled: false,
-                    file: mockTestFilePath,
-                    line: 3
-                  }
-                ]
-              }
-            ]);
-
-            expect(identicalTestDefinition2).toEqual([
-              {
-                test: {
-                  description: 'identical inner test',
-                  type: TestType.Test,
-                  state: TestDefinitionState.Default,
-                  disabled: false,
-                  file: mockTestFilePath,
-                  line: 11
-                },
-                suite: [
-                  {
-                    description: 'test suite 1',
-                    type: TestType.Suite,
-                    state: TestDefinitionState.Default,
-                    disabled: false,
-                    file: mockTestFilePath,
-                    line: 1
-                  },
-                  {
-                    description: 'test suite 1-2',
-                    type: TestType.Suite,
-                    state: TestDefinitionState.Default,
-                    disabled: false,
-                    file: mockTestFilePath,
-                    line: 9
-                  },
-                  {
-                    description: 'identical inner suite',
-                    type: TestType.Suite,
-                    state: TestDefinitionState.Default,
-                    disabled: false,
-                    file: mockTestFilePath,
-                    line: 10
-                  }
-                ]
-              }
-            ]);
+              it('should return false for files not matching the designated test file patterns', () => {
+                const result = testLocator.isTestFile('abc-spec.js');
+                expect(result).toBe(false);
+              });
+            });
           });
         });
       });


### PR DESCRIPTION
* Addresses a long-standing issue where parameterized tests display as unmapped, as well as tests with template or computed string descriptions