### PR TITLE
use path instead of posix-specific path

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"icon": "docs/img/extension-icon-128.png",
 	"author": "Lucas Ononiwu",
 	"publisher": "lucono",
-	"version": "0.7.2",
+	"version": "0.7.3",
 	"license": "MIT",
 	"homepage": "https://github.com/lucono/karma-test-explorer",
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"icon": "docs/img/extension-icon-128.png",
 	"author": "Lucas Ononiwu",
 	"publisher": "lucono",
-	"version": "0.7.3",
+	"version": "0.7.2",
 	"license": "MIT",
 	"homepage": "https://github.com/lucono/karma-test-explorer",
 	"repository": {

--- a/src/frameworks/angular/angular-util.ts
+++ b/src/frameworks/angular/angular-util.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from 'fs';
-import * as path from 'path';
+import { posix } from 'path';
 import { Logger } from '../../util/logging/logger';
 import { normalizePath } from '../../util/utils';
 import { AngularProjectInfo } from './angular-project-info';
@@ -19,7 +19,7 @@ const getAngularJsonWorkspaceInfo = (
   angularConfigRootPath: string,
   logger: Logger
 ): AngularWorkspaceInfo | undefined => {
-  const angularJsonConfigPath = normalizePath(path.resolve(angularConfigRootPath, 'angular.json'));
+  const angularJsonConfigPath = normalizePath(posix.resolve(angularConfigRootPath, 'angular.json'));
 
   if (!existsSync(angularJsonConfigPath)) {
     logger.debug(() => `Cannot get Angular projects - Angular Json file does not exist: ${angularJsonConfigPath}`);
@@ -41,8 +41,8 @@ const getAngularJsonWorkspaceInfo = (
     if (projectConfig.architect.test === undefined || projectConfig.architect.test.options.karmaConfig === undefined) {
       continue;
     }
-    const projectPath = path.resolve(angularConfigRootPath, projectConfig.root);
-    const karmaConfigPath = path.resolve(angularConfigRootPath, projectConfig.architect.test.options.karmaConfig);
+    const projectPath = posix.resolve(angularConfigRootPath, projectConfig.root);
+    const karmaConfigPath = posix.resolve(angularConfigRootPath, projectConfig.architect.test.options.karmaConfig);
 
     const project: AngularProjectInfo = {
       name: projectName,
@@ -72,7 +72,7 @@ const getAngularCliJsonWorkspaceInfo = (
   angularConfigRootPath: string,
   logger: Logger
 ): AngularWorkspaceInfo | undefined => {
-  const angularCliJsonConfigPath = normalizePath(path.resolve(angularConfigRootPath, '.angular-cli.json'));
+  const angularCliJsonConfigPath = normalizePath(posix.resolve(angularConfigRootPath, '.angular-cli.json'));
 
   if (!existsSync(angularCliJsonConfigPath)) {
     logger.debug(
@@ -94,8 +94,8 @@ const getAngularCliJsonWorkspaceInfo = (
 
   for (const app of angularCliJson.apps) {
     const projectName: string = app.name || angularCliJson.project.name;
-    const projectPath = normalizePath(path.resolve(angularConfigRootPath, app.root));
-    const karmaConfigPath = path.resolve(angularConfigRootPath, angularCliJson.test.karma.config);
+    const projectPath = normalizePath(posix.resolve(angularConfigRootPath, app.root));
+    const karmaConfigPath = posix.resolve(angularConfigRootPath, angularCliJson.test.karma.config);
 
     const project: AngularProjectInfo = {
       name: projectName,

--- a/src/frameworks/angular/angular-util.ts
+++ b/src/frameworks/angular/angular-util.ts
@@ -19,13 +19,18 @@ const getAngularJsonWorkspaceInfo = (
   angularConfigRootPath: string,
   logger: Logger
 ): AngularWorkspaceInfo | undefined => {
-  const angularJsonConfigPath = normalizePath(posix.resolve(angularConfigRootPath, 'angular.json'));
+  const angularJsonConfigPath = normalizePath(posix.join(angularConfigRootPath, 'angular.json'));
 
   if (!existsSync(angularJsonConfigPath)) {
     logger.debug(() => `Cannot get Angular projects - Angular Json file does not exist: ${angularJsonConfigPath}`);
     return undefined;
   }
-  const angularJson = JSON.parse(readFileSync(angularJsonConfigPath, 'utf-8'));
+  let angularJson: any;
+  try {
+    angularJson = JSON.parse(readFileSync(angularJsonConfigPath, 'utf-8'));
+  } catch (e) {
+    // do nothing
+  }
 
   if (!angularJson) {
     logger.debug(() => `Cannot get Angular projects - Failed to read Angular Json file: ${angularJsonConfigPath}`);
@@ -41,8 +46,10 @@ const getAngularJsonWorkspaceInfo = (
     if (projectConfig.architect.test === undefined || projectConfig.architect.test.options.karmaConfig === undefined) {
       continue;
     }
-    const projectPath = posix.resolve(angularConfigRootPath, projectConfig.root);
-    const karmaConfigPath = posix.resolve(angularConfigRootPath, projectConfig.architect.test.options.karmaConfig);
+    const projectPath = normalizePath(posix.join(angularConfigRootPath, projectConfig.root));
+    const karmaConfigPath = normalizePath(
+      posix.join(angularConfigRootPath, projectConfig.architect.test.options.karmaConfig)
+    );
 
     const project: AngularProjectInfo = {
       name: projectName,
@@ -72,7 +79,7 @@ const getAngularCliJsonWorkspaceInfo = (
   angularConfigRootPath: string,
   logger: Logger
 ): AngularWorkspaceInfo | undefined => {
-  const angularCliJsonConfigPath = normalizePath(posix.resolve(angularConfigRootPath, '.angular-cli.json'));
+  const angularCliJsonConfigPath = normalizePath(posix.join(angularConfigRootPath, '.angular-cli.json'));
 
   if (!existsSync(angularCliJsonConfigPath)) {
     logger.debug(
@@ -80,7 +87,12 @@ const getAngularCliJsonWorkspaceInfo = (
     );
     return undefined;
   }
-  const angularCliJson = JSON.parse(readFileSync(angularCliJsonConfigPath, 'utf-8'));
+  let angularCliJson: any;
+  try {
+    angularCliJson = JSON.parse(readFileSync(angularCliJsonConfigPath, 'utf-8'));
+  } catch (e) {
+    // do nothing
+  }
 
   if (!angularCliJson) {
     logger.debug(
@@ -94,8 +106,8 @@ const getAngularCliJsonWorkspaceInfo = (
 
   for (const app of angularCliJson.apps) {
     const projectName: string = app.name || angularCliJson.project.name;
-    const projectPath = normalizePath(posix.resolve(angularConfigRootPath, app.root));
-    const karmaConfigPath = posix.resolve(angularConfigRootPath, angularCliJson.test.karma.config);
+    const projectPath = normalizePath(posix.join(angularConfigRootPath, app.root));
+    const karmaConfigPath = normalizePath(posix.join(angularConfigRootPath, angularCliJson.test.karma.config));
 
     const project: AngularProjectInfo = {
       name: projectName,

--- a/src/frameworks/angular/angular-util.ts
+++ b/src/frameworks/angular/angular-util.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from 'fs';
-import { posix } from 'path';
+import * as path from 'path';
 import { Logger } from '../../util/logging/logger';
 import { normalizePath } from '../../util/utils';
 import { AngularProjectInfo } from './angular-project-info';
@@ -19,7 +19,7 @@ const getAngularJsonWorkspaceInfo = (
   angularConfigRootPath: string,
   logger: Logger
 ): AngularWorkspaceInfo | undefined => {
-  const angularJsonConfigPath = normalizePath(posix.resolve(angularConfigRootPath, 'angular.json'));
+  const angularJsonConfigPath = normalizePath(path.resolve(angularConfigRootPath, 'angular.json'));
 
   if (!existsSync(angularJsonConfigPath)) {
     logger.debug(() => `Cannot get Angular projects - Angular Json file does not exist: ${angularJsonConfigPath}`);
@@ -41,8 +41,8 @@ const getAngularJsonWorkspaceInfo = (
     if (projectConfig.architect.test === undefined || projectConfig.architect.test.options.karmaConfig === undefined) {
       continue;
     }
-    const projectPath = posix.resolve(angularConfigRootPath, projectConfig.root);
-    const karmaConfigPath = posix.resolve(angularConfigRootPath, projectConfig.architect.test.options.karmaConfig);
+    const projectPath = path.resolve(angularConfigRootPath, projectConfig.root);
+    const karmaConfigPath = path.resolve(angularConfigRootPath, projectConfig.architect.test.options.karmaConfig);
 
     const project: AngularProjectInfo = {
       name: projectName,
@@ -72,7 +72,7 @@ const getAngularCliJsonWorkspaceInfo = (
   angularConfigRootPath: string,
   logger: Logger
 ): AngularWorkspaceInfo | undefined => {
-  const angularCliJsonConfigPath = normalizePath(posix.resolve(angularConfigRootPath, '.angular-cli.json'));
+  const angularCliJsonConfigPath = normalizePath(path.resolve(angularConfigRootPath, '.angular-cli.json'));
 
   if (!existsSync(angularCliJsonConfigPath)) {
     logger.debug(
@@ -94,8 +94,8 @@ const getAngularCliJsonWorkspaceInfo = (
 
   for (const app of angularCliJson.apps) {
     const projectName: string = app.name || angularCliJson.project.name;
-    const projectPath = normalizePath(posix.resolve(angularConfigRootPath, app.root));
-    const karmaConfigPath = posix.resolve(angularConfigRootPath, angularCliJson.test.karma.config);
+    const projectPath = normalizePath(path.resolve(angularConfigRootPath, app.root));
+    const karmaConfigPath = path.resolve(angularConfigRootPath, angularCliJson.test.karma.config);
 
     const project: AngularProjectInfo = {
       name: projectName,

--- a/test/frameworks/angular/angular-utils.test.ts
+++ b/test/frameworks/angular/angular-utils.test.ts
@@ -1,0 +1,133 @@
+import { getAngularWorkspaceInfo } from '../../../src/frameworks/angular/angular-util';
+import { normalizePath } from '../../../src/util/utils';
+
+jest.mock('fs');
+const fs = require('fs'); // require necessary for jest to work
+
+const logger = {
+  debug: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  trace: jest.fn(),
+  dispose: jest.fn()
+};
+
+describe('angular-utils.getAngularWorkspaceInfo', () => {
+  const angularConfigRootPaths = [
+    ['Unix', '/angular-config-root-path'],
+    ['Windows', 'C:\\angular-config-root-path']
+  ];
+
+  beforeEach(jest.clearAllMocks);
+
+  angularConfigRootPaths.forEach(item => {
+    const [platform, angularConfigRootPath] = item;
+
+    it(`should return undefined if no angular definition exists (${platform})`, () => {
+      fs.existsSync.mockReturnValue(false);
+      const result = getAngularWorkspaceInfo(angularConfigRootPath, logger);
+      expect(result).toBeUndefined();
+      expect(fs.existsSync).toHaveBeenCalledWith(normalizePath(`${angularConfigRootPath}/angular.json`));
+      expect(fs.existsSync).toHaveBeenCalledWith(normalizePath(`${angularConfigRootPath}/.angular-cli.json`));
+    });
+
+    it(`should return undefined if the angular definitions are invalid (${platform})`, () => {
+      fs.existsSync.mockReturnValue(true);
+      fs.readFileSync.mockImplementation(() => 'invalid json');
+      const result = getAngularWorkspaceInfo(angularConfigRootPath, logger);
+      expect(result).toBeUndefined();
+      expect(fs.existsSync).toHaveBeenCalledWith(normalizePath(`${angularConfigRootPath}/angular.json`));
+      expect(fs.existsSync).toHaveBeenCalledWith(normalizePath(`${angularConfigRootPath}/.angular-cli.json`));
+      expect(fs.readFileSync).toHaveBeenCalledWith(normalizePath(`${angularConfigRootPath}/angular.json`), 'utf-8');
+      expect(fs.readFileSync).toHaveBeenCalledWith(
+        normalizePath(`${angularConfigRootPath}/.angular-cli.json`),
+        'utf-8'
+      );
+    });
+
+    it('should return a valid configuration from angular.json', () => {
+      fs.existsSync.mockImplementation((name: any) => (name as string).endsWith('angular.json'));
+      fs.readFileSync.mockImplementation(() =>
+        JSON.stringify({
+          // defaultProject: 'default-project', // deprecated!
+          projects: {
+            'project-1': {
+              root: 'project-1',
+              architect: {
+                test: {
+                  options: {
+                    karmaConfig: 'project-1/karma.conf.js'
+                  }
+                }
+              }
+            },
+            'project-2': {
+              root: 'project-2',
+              architect: {
+                test: {
+                  options: {
+                    karmaConfig: 'project-2/karma.conf.js'
+                  }
+                }
+              }
+            },
+            'project-3': {
+              root: 'project-3',
+              architect: {}
+            }
+          }
+        })
+      );
+      const result = getAngularWorkspaceInfo(angularConfigRootPath, logger);
+      expect(result).toBeDefined();
+      expect(result!.defaultProject).toEqual(result!.projects[0]);
+      expect(result!.projects.length).toBe(2);
+      expect(result!.projects[0].name).toBe('project-1');
+      expect(result!.projects[0].rootPath).toBe(normalizePath(angularConfigRootPath + '/project-1'));
+      expect(result!.projects[0].karmaConfigPath).toBe(
+        normalizePath(angularConfigRootPath + '/project-1/karma.conf.js')
+      );
+      expect(result!.projects[1].name).toBe('project-2');
+      expect(result!.projects[1].rootPath).toBe(normalizePath(angularConfigRootPath + '/project-2'));
+      expect(result!.projects[1].karmaConfigPath).toBe(
+        normalizePath(angularConfigRootPath + '/project-2/karma.conf.js')
+      );
+    });
+
+    it('should return a valid configuration from .angular-cli.json', () => {
+      fs.existsSync.mockImplementation((name: any) => (name as string).endsWith('.angular-cli.json'));
+      fs.readFileSync.mockImplementation(() =>
+        JSON.stringify({
+          project: {
+            name: 'my-app'
+          },
+          apps: [
+            {
+              root: 'src-1'
+            },
+            {
+              name: 'my-app-2',
+              root: 'src-2'
+            }
+          ],
+          test: {
+            karma: {
+              config: './karma.conf.js'
+            }
+          }
+        })
+      );
+      const result = getAngularWorkspaceInfo(angularConfigRootPath, logger);
+      expect(result).toBeDefined();
+      expect(result!.defaultProject).toEqual(result!.projects[0]);
+      expect(result!.projects.length).toBe(2);
+      expect(result!.projects[0].name).toBe('my-app');
+      expect(result!.projects[0].rootPath).toBe(normalizePath(angularConfigRootPath + '/src-1'));
+      expect(result!.projects[0].karmaConfigPath).toBe(normalizePath(angularConfigRootPath + '/karma.conf.js'));
+      expect(result!.projects[1].name).toBe('my-app-2');
+      expect(result!.projects[1].rootPath).toBe(normalizePath(angularConfigRootPath + '/src-2'));
+      expect(result!.projects[1].karmaConfigPath).toBe(normalizePath(angularConfigRootPath + '/karma.conf.js'));
+    });
+  });
+});


### PR DESCRIPTION
addresses #38, but likely doesn't fully eliminate the issue.

I've noticed that there's a lot of explicit `posix` type path usage and manual path parsing etc. It seems to me that the scope of the extension is merely a bridge between karma/angular-cli and the UI, which leads me to believe that manual path wrangling (posix paths on windows and vice versa) shouldn't really be necessary.
I don't want to break stuff I don't fully understand, so I only took out any posix path manipulation that touches `angularConfigRootPath` in `angular-utils` since I can see that it's a windows path from the start, but I'm certain that the same could be done throughout the project. I generally advise against manual path manipulation and explicit platform distinction.

This change correctly identifed my angular project on my D: drive and started the angular cli (without any manual settings). Test detection and execution work as expected. I did `npm validate` and got 225/238 tests passed, the same as on `master`.

I've taken the liberty to increment the path level.