### PR TITLE
Add per-project browser config processing

### DIFF
--- a/src/core/config/browsers/browser-factory.ts
+++ b/src/core/config/browsers/browser-factory.ts
@@ -1,0 +1,21 @@
+import { BrowserHelper } from './browser-helper.js';
+import { ChromeBrowserHelper } from './chrome-helper.js';
+import { ElectronBrowserHelper } from './electron-helper.js';
+import { FirefoxBrowserHelper } from './firefox-helper.js';
+import { MsEdgeBrowserHelper } from './msedge-helper.js';
+
+export class BrowserHelperFactory {
+  static BROWSER_HELPER_INSTANCES = [
+    new ChromeBrowserHelper(),
+    new FirefoxBrowserHelper(),
+    new MsEdgeBrowserHelper(),
+    new ElectronBrowserHelper()
+  ];
+
+  public static getBrowserHelper(browserType: string): BrowserHelper {
+    return (
+      this.BROWSER_HELPER_INSTANCES.find(helper => helper.isSupportedBrowser(browserType)) ??
+      this.BROWSER_HELPER_INSTANCES[0]
+    );
+  }
+}

--- a/src/core/config/browsers/browser-helper.ts
+++ b/src/core/config/browsers/browser-helper.ts
@@ -1,0 +1,66 @@
+import { DebugConfiguration } from 'vscode';
+
+import { CustomLauncher } from 'karma';
+
+import { ProjectConfigSetting } from '../config-setting.js';
+import { ConfigStore } from '../config-store.js';
+
+export abstract class BrowserHelper {
+  public static DEFAULT_DEBUGGING_PORT: number | undefined = 9222;
+  public abstract get supportedBrowsers(): string[];
+  public abstract get debuggerType(): string;
+  public abstract get debuggingPortFlag(): string;
+
+  public abstract getCustomLauncher(
+    browserType: string,
+    customLaucher: CustomLauncher | undefined,
+    config: ConfigStore<ProjectConfigSetting>
+  ): CustomLauncher;
+
+  public isSupportedBrowser(browserType: string): boolean {
+    return this.supportedBrowsers.some(supportedBrowser => browserType.startsWith(supportedBrowser));
+  }
+
+  public getDefaultDebuggerConfig(): DebugConfiguration {
+    return {
+      name: 'Karma Test Explorer Debugging',
+      type: this.debuggerType,
+      request: 'attach',
+      browserAttachLocation: 'workspace',
+      address: 'localhost',
+      port: BrowserHelper.DEFAULT_DEBUGGING_PORT,
+      timeout: 60000
+    };
+  }
+
+  public addCustomLauncherDebugPort(customLaucher: CustomLauncher, debugPort: number | undefined): void {
+    if (!customLaucher || debugPort === undefined) {
+      return;
+    }
+    customLaucher.flags = customLaucher.flags?.map(flag =>
+      flag.startsWith(this.debuggingPortFlag) ? `${this.debuggingPortFlag} ${debugPort}` : flag
+    );
+  }
+
+  public getDefaultDebugPort(
+    customLauncher: Readonly<CustomLauncher>,
+    debuggerConfig: Readonly<DebugConfiguration>
+  ): number | undefined {
+    const isSupportedLaunchType = this.supportedBrowsers.some(browser => customLauncher.base.startsWith(browser));
+    const isSupportedDebugConfig = debuggerConfig.type === this.debuggerType;
+    if (!isSupportedLaunchType || !isSupportedDebugConfig) {
+      return undefined;
+    }
+
+    let configuredPort: number | undefined;
+    const browserDebugPortFlag = customLauncher.flags?.find(flag => flag.startsWith(this.debuggingPortFlag));
+
+    if (browserDebugPortFlag) {
+      const portPosition = browserDebugPortFlag.search(/[0-9]+$/g);
+      const portString = portPosition !== -1 ? browserDebugPortFlag.substring(portPosition) : undefined;
+      configuredPort = portString ? parseInt(portString, 10) : undefined;
+    }
+
+    return configuredPort ?? BrowserHelper.DEFAULT_DEBUGGING_PORT;
+  }
+}

--- a/src/core/config/browsers/browser-helper.ts
+++ b/src/core/config/browsers/browser-helper.ts
@@ -38,7 +38,7 @@ export abstract class BrowserHelper {
       return;
     }
     customLaucher.flags = customLaucher.flags?.map(flag =>
-      flag.startsWith(this.debuggingPortFlag) ? `${this.debuggingPortFlag} ${debugPort}` : flag
+      flag.startsWith(this.debuggingPortFlag) ? `${this.debuggingPortFlag}=${debugPort}` : flag
     );
   }
 

--- a/src/core/config/browsers/chrome-helper.ts
+++ b/src/core/config/browsers/chrome-helper.ts
@@ -1,0 +1,60 @@
+import isDocker from 'is-docker';
+import { CustomLauncher } from 'karma';
+
+import { GeneralConfigSetting, ProjectConfigSetting } from '../config-setting.js';
+import { ConfigStore } from '../config-store.js';
+import { ContainerMode } from '../extension-config.js';
+import { BrowserHelper } from './browser-helper.js';
+
+export class ChromeBrowserHelper extends BrowserHelper {
+  private static NO_SANDBOX_FLAG: string = '--no-sandbox';
+  private static HEADLESS_FLAGS: string[] = ['--headless', '--disable-gpu', '--disable-dev-shm-usage'];
+  static DEFAULT_DEBUGGING_PORT: number | undefined;
+
+  public get supportedBrowsers(): string[] {
+    return ['Chrome', 'Chromium', 'Dartium'];
+  }
+  public get debuggerType(): string {
+    return 'chrome';
+  }
+  public get debuggingPortFlag(): string {
+    return '--remote-debugging-port';
+  }
+
+  public getCustomLauncher(
+    browserType: string,
+    customLaucher: CustomLauncher | undefined,
+    config: ConfigStore<ProjectConfigSetting>
+  ): CustomLauncher {
+    const configuredLauncher: CustomLauncher = customLaucher ?? {
+      base: this.isSupportedBrowser(browserType) ? browserType : this.supportedBrowsers[0],
+      flags: [
+        ...ChromeBrowserHelper.HEADLESS_FLAGS,
+        `${this.debuggingPortFlag}=${BrowserHelper.DEFAULT_DEBUGGING_PORT}`
+      ]
+    };
+
+    const configuredContainerMode: ContainerMode = config.get(GeneralConfigSetting.ContainerMode);
+    const isNonHeadlessMode = !!config.get(GeneralConfigSetting.NonHeadlessModeEnabled);
+
+    const isContainerMode =
+      configuredContainerMode === ContainerMode.Enabled
+        ? true
+        : configuredContainerMode === ContainerMode.Disabled
+        ? false
+        : isDocker();
+
+    let launcherFlags = (configuredLauncher.flags ??= []);
+
+    if (isContainerMode && !launcherFlags.includes(ChromeBrowserHelper.NO_SANDBOX_FLAG)) {
+      launcherFlags = [...launcherFlags, ChromeBrowserHelper.NO_SANDBOX_FLAG];
+    }
+
+    if (!isContainerMode && !configuredLauncher.base.includes('Headless') && isNonHeadlessMode) {
+      launcherFlags = launcherFlags.filter(flag => !ChromeBrowserHelper.HEADLESS_FLAGS.includes(flag));
+    }
+
+    const customLauncher: CustomLauncher = { ...configuredLauncher, flags: launcherFlags };
+    return customLauncher;
+  }
+}

--- a/src/core/config/browsers/electron-helper.ts
+++ b/src/core/config/browsers/electron-helper.ts
@@ -1,0 +1,50 @@
+import isDocker from 'is-docker';
+import { CustomLauncher } from 'karma';
+
+import { GeneralConfigSetting, ProjectConfigSetting } from '../config-setting.js';
+import { ConfigStore } from '../config-store.js';
+import { ContainerMode } from '../extension-config.js';
+import { BrowserHelper } from './browser-helper.js';
+
+export class ElectronBrowserHelper extends BrowserHelper {
+  static DEFAULT_DEBUGGING_PORT: number | undefined;
+
+  public get supportedBrowsers(): string[] {
+    return ['Electron'];
+  }
+  public get debuggerType(): string {
+    return 'chrome';
+  }
+  public get debuggingPortFlag(): string {
+    return '--remote-debugging-port';
+  }
+
+  public getCustomLauncher(
+    browserType: string,
+    customLaucher: CustomLauncher | undefined,
+    config: ConfigStore<ProjectConfigSetting>
+  ): CustomLauncher {
+    const customLauncher: CustomLauncher = customLaucher ?? {
+      base: browserType,
+      flags: [`${this.debuggingPortFlag}=${BrowserHelper.DEFAULT_DEBUGGING_PORT}`]
+    };
+
+    const configuredContainerMode: ContainerMode = config.get(GeneralConfigSetting.ContainerMode);
+    const isNonHeadlessMode = !!config.get(GeneralConfigSetting.NonHeadlessModeEnabled);
+
+    const isContainerMode =
+      configuredContainerMode === ContainerMode.Enabled
+        ? true
+        : configuredContainerMode === ContainerMode.Disabled
+        ? false
+        : isDocker();
+
+    if (!isContainerMode && isNonHeadlessMode) {
+      const browserWindowOptions = ((customLauncher as any).browserWindowOptions ??= {});
+      browserWindowOptions.webPreferences ??= {};
+      browserWindowOptions.webPreferences.show = true;
+    }
+
+    return customLauncher;
+  }
+}

--- a/src/core/config/browsers/firefox-helper.ts
+++ b/src/core/config/browsers/firefox-helper.ts
@@ -1,0 +1,51 @@
+import isDocker from 'is-docker';
+import { CustomLauncher } from 'karma';
+
+import { GeneralConfigSetting, ProjectConfigSetting } from '../config-setting.js';
+import { ConfigStore } from '../config-store.js';
+import { ContainerMode } from '../extension-config.js';
+import { BrowserHelper } from './browser-helper.js';
+
+export class FirefoxBrowserHelper extends BrowserHelper {
+  private static HEADLESS_FLAGS: string[] = ['-headless'];
+
+  public get supportedBrowsers(): string[] {
+    return ['Firefox'];
+  }
+  public get debuggerType(): string {
+    return 'firefox';
+  }
+  public get debuggingPortFlag(): string {
+    return '-start-debugger-server';
+  }
+
+  public getCustomLauncher(
+    browserType: string,
+    customLaucher: CustomLauncher | undefined,
+    config: ConfigStore<ProjectConfigSetting>
+  ): CustomLauncher {
+    const configuredLauncher: CustomLauncher = customLaucher ?? {
+      base: browserType,
+      flags: [`${this.debuggingPortFlag} ${BrowserHelper.DEFAULT_DEBUGGING_PORT}`]
+    };
+
+    const configuredContainerMode: ContainerMode = config.get(GeneralConfigSetting.ContainerMode);
+    const isNonHeadlessMode = !!config.get(GeneralConfigSetting.NonHeadlessModeEnabled);
+
+    const isContainerMode =
+      configuredContainerMode === ContainerMode.Enabled
+        ? true
+        : configuredContainerMode === ContainerMode.Disabled
+        ? false
+        : isDocker();
+
+    let launcherFlags = (configuredLauncher.flags ??= []);
+
+    if (!isContainerMode && !configuredLauncher.base.includes('Headless') && isNonHeadlessMode) {
+      launcherFlags = launcherFlags.filter(flag => !FirefoxBrowserHelper.HEADLESS_FLAGS.includes(flag));
+    }
+
+    const customLauncher: CustomLauncher = { ...configuredLauncher, flags: launcherFlags };
+    return customLauncher;
+  }
+}

--- a/src/core/config/browsers/firefox-helper.ts
+++ b/src/core/config/browsers/firefox-helper.ts
@@ -24,10 +24,20 @@ export class FirefoxBrowserHelper extends BrowserHelper {
     customLaucher: CustomLauncher | undefined,
     config: ConfigStore<ProjectConfigSetting>
   ): CustomLauncher {
-    const configuredLauncher: CustomLauncher = customLaucher ?? {
-      base: browserType,
-      flags: [`${this.debuggingPortFlag} ${BrowserHelper.DEFAULT_DEBUGGING_PORT}`]
-    };
+    const configuredLauncher: CustomLauncher =
+      customLaucher ??
+      ({
+        base: browserType,
+        flags: [
+          ...FirefoxBrowserHelper.HEADLESS_FLAGS,
+          `${this.debuggingPortFlag} ${BrowserHelper.DEFAULT_DEBUGGING_PORT}`
+        ],
+        prefs: {
+          'devtools.debugger.remote-enabled': true,
+          'devtools.chrome.enabled': true,
+          'devtools.debugger.prompt-connection': false
+        }
+      } as any);
 
     const configuredContainerMode: ContainerMode = config.get(GeneralConfigSetting.ContainerMode);
     const isNonHeadlessMode = !!config.get(GeneralConfigSetting.NonHeadlessModeEnabled);
@@ -47,5 +57,14 @@ export class FirefoxBrowserHelper extends BrowserHelper {
 
     const customLauncher: CustomLauncher = { ...configuredLauncher, flags: launcherFlags };
     return customLauncher;
+  }
+
+  public addCustomLauncherDebugPort(customLaucher: CustomLauncher, debugPort: number | undefined): void {
+    if (!customLaucher || debugPort === undefined) {
+      return;
+    }
+    customLaucher.flags = customLaucher.flags?.map(flag =>
+      flag.startsWith(this.debuggingPortFlag) ? `${this.debuggingPortFlag} ${debugPort}` : flag
+    );
   }
 }

--- a/src/core/config/browsers/msedge-helper.ts
+++ b/src/core/config/browsers/msedge-helper.ts
@@ -1,0 +1,10 @@
+import { ChromeBrowserHelper } from './chrome-helper.js';
+
+export class MsEdgeBrowserHelper extends ChromeBrowserHelper {
+  public get supportedBrowsers(): string[] {
+    return ['Edge'];
+  }
+  public get debuggerType(): string {
+    return 'msedge';
+  }
+}

--- a/src/frameworks/karma/config/karma-config-loader.ts
+++ b/src/frameworks/karma/config/karma-config-loader.ts
@@ -1,11 +1,8 @@
 import { CustomLauncher, InlinePluginDef, Config as KarmaConfig } from 'karma';
 import { resolve } from 'path';
 
-import {
-  CHROME_BROWSER_DEBUGGING_PORT_FLAG,
-  KARMA_BROWSER_CAPTURE_MIN_TIMEOUT,
-  KARMA_CUSTOM_LAUNCHER_BROWSER_NAME
-} from '../../../constants.js';
+import { KARMA_BROWSER_CAPTURE_MIN_TIMEOUT, KARMA_CUSTOM_LAUNCHER_BROWSER_NAME } from '../../../constants.js';
+import { BrowserHelperFactory } from '../../../core/config/browsers/browser-factory.js';
 import { Logger } from '../../../util/logging/logger.js';
 import { asNonBlankStringOrUndefined } from '../../../util/utils.js';
 import { KarmaEnvironmentVariable } from '../karma-environment-variable.js';
@@ -67,6 +64,7 @@ export class KarmaConfigLoader {
     } else {
       const debugPortString = process.env[KarmaEnvironmentVariable.DebugPort];
       const debugPort: number | undefined = debugPortString ? parseInt(debugPortString, 10) : undefined;
+      this.logger.debug(() => `Using debug port: ${debugPort}`);
 
       const customLauncherString = process.env[KarmaEnvironmentVariable.CustomLauncher]!;
       const customLaucherObject = customLauncherString ? JSON.parse(customLauncherString) : {};
@@ -125,11 +123,7 @@ export class KarmaConfigLoader {
   }
 
   private addCustomLauncherDebugPort(customLaucher: CustomLauncher, debugPort: number | undefined) {
-    if (!customLaucher || debugPort === undefined) {
-      return;
-    }
-    customLaucher.flags = customLaucher.flags?.map(flag =>
-      flag.startsWith(CHROME_BROWSER_DEBUGGING_PORT_FLAG) ? `${CHROME_BROWSER_DEBUGGING_PORT_FLAG}=${debugPort}` : flag
-    );
+    const browserHelper = BrowserHelperFactory.getBrowserHelper(customLaucher?.base ?? '');
+    browserHelper.addCustomLauncherDebugPort(customLaucher, debugPort);
   }
 }


### PR DESCRIPTION
I've done an initial set of changes to address the first pass solution for #71. I've added a set of browser helper classes that can generate and process custom launcher configs for the following browsers:
* Chrome
* Electron
* Firefox
* Edge

It does the custom launcher processing at the extension config level, rather than within the karma config processing, but also hooks into the karma config loader to override the debug port.

I've not adjusted any tests yet, just looking for feedback or suggestions on the approach.
