### PR TITLE
Add vscode debugging configuration

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    "recommendations": [
+        "orta.vscode-jest",
+        "hbenl.vscode-test-explorer",
+        "dbaeumer.vscode-eslint"
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,6 +11,13 @@
       ],
       "outFiles": [
         "${workspaceFolder}/out/**/*.js"
+      ],
+      "preLaunchTask": "Rebuild Test Explorer (Dev)",
+      "sourceMaps": true,
+      "resolveSourceMapLocations": [
+        "${workspaceFolder}/dist/**",
+        "${workspaceFolder}/out/**",
+        "!**/node_modules/**"
       ]
     },
     {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,14 +1,23 @@
 {
 	"[typescript]": {
 		"editor.defaultFormatter": "dbaeumer.vscode-eslint",
+		"editor.codeActionsOnSave": {
+			"source.fixAll": true
+		}
+	},
+	"[javascript]": {
+		"editor.codeActionsOnSave": {
+			"source.fixAll": true
+		}
 	},
 	"typescript.tsdk": "node_modules/typescript/lib",
 	"eslint.format.enable": true,
-
+	"editor.indentSize": 2,
+	"editor.insertSpaces": true,
 	"files.exclude": {
 		".git": true,
 		"node_modules": true
 	},
-
-	"jest.enableCodeLens": false
+	"jest.enableCodeLens": false,
+	"files.eol": "\n"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,74 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "npm",
+			"script": "build",
+			"group": "build",
+			"problemMatcher": [
+				"$tsc"
+			],
+			"label": "Build Karma Test Explorer",
+			"detail": "tsc"
+		},
+		{
+			"type": "npm",
+			"script": "bundle",
+			"group": "build",
+			"problemMatcher": [
+				"$tsc"
+			],
+			"label": "Bundle Karma Test Explorer",
+			"detail": "bundle"
+		},
+		{
+			"type": "npm",
+			"script": "bundle-dev",
+			"group": "build",
+			"problemMatcher": [
+				"$tsc"
+			],
+			"label": "Bundle Karma Test Explorer (Dev)",
+			"detail": "bundle-dev"
+		},
+		{
+			"dependsOn": [
+				"Clean Build Output",
+				"Build Karma Test Explorer",
+				"Bundle Karma Test Explorer (Dev)"
+			],
+			"dependsOrder": "sequence",
+			"label": "Rebuild Test Explorer (Dev)",
+			"problemMatcher": []
+		},
+		{
+			"dependsOn": [
+				"Clean Build Output",
+				"Build Karma Test Explorer",
+				"Bundle Karma Test Explorer"
+			],
+			"dependsOrder": "sequence",
+			"label": "Rebuild Test Explorer",
+			"problemMatcher": []
+		},
+		{
+			"dependsOn": [
+				"Rebuild Test Explorer"
+			],
+			"label": "Package Extension",
+			"type": "npm",
+			"script": "package",
+			"detail": "package",
+			"problemMatcher": [],
+			"group": "build"
+		},
+		{
+			"label": "Clean Build Output",
+			"type": "npm",
+			"script": "clean",
+			"detail": "clean",
+			"problemMatcher": [],
+			"group": "build"
+		}
+	]
+}

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -24,7 +24,7 @@ export default {
   minifyIdentifiers: true,
   minifyWhitespace: true,
   minifySyntax: false,
-  sourcemap: false,
+  sourcemap: process.argv.includes('--dev'),
   keepNames: true,
   tsconfig: './tsconfig.json'
 };

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 		"watch": "tsc -w",
 		"test": "jest -c jest.config.js",
 		"bundle": "node ./scripts/bundle.js",
+		"bundle-dev": "node ./scripts/bundle.js --dev",
 		"package": "npx vsce package --githubBranch master",
 		"publish": "npx vsce publish --githubBranch master",
 		"validate": "npm run format:check && npm run lint:check && npm run rebuild && npm run test && npm run bundle && npm run package"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "noUnusedLocals": true,
     "removeComments": true,
     "skipLibCheck": true,
-    "allowJs": true
+    "allowJs": true,
+    "sourceMap": true
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
These are the settings changes I made to get extension debugging to work nicely within vscode. The launch config auto-builds to apply any changes to the bundled output, source maps are enabled so that breakpoints can be set in typescript files, and I've added recommended extensions so that those not using the devcontainer can be prompted to get the same extensions. I've also updated the workspace settings to better match the linter configuration.