### PR TITLE
Initial NX support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@babel/parser": "^7.21.4",
+				"@nodelib/fs.walk": "^2.0.0",
 				"bluebird": "^3.7.2",
 				"dotenv": "^16.0.3",
 				"dotenv-expand": "^10.0.0",
@@ -2135,15 +2136,23 @@
 			"dev": true
 		},
 		"node_modules/@nodelib/fs.scandir": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-3.0.0.tgz",
+			"integrity": "sha512-ktI9+PxfHYtKjF3cLTUAh2N+b8MijCRPNwKJNqTVdL0gB0QxLU2rIRaZ1t71oEa3YBDE6bukH1sR0+CDnpp/Mg==",
 			"dependencies": {
-				"@nodelib/fs.stat": "2.0.5",
-				"run-parallel": "^1.1.9"
+				"@nodelib/fs.stat": "3.0.0",
+				"run-parallel": "^1.2.0"
 			},
 			"engines": {
-				"node": ">= 8"
+				"node": ">=16.14.0"
+			}
+		},
+		"node_modules/@nodelib/fs.scandir/node_modules/@nodelib/fs.stat": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-3.0.0.tgz",
+			"integrity": "sha512-2tQOI38s19P9i7X/Drt0v8iMA+KMsgdhB/dyPER+e+2Y8L1Z7QvnuRdW/uLuf5YRFUYmnj4bMA6qCuZHFI1GDQ==",
+			"engines": {
+				"node": ">=16.14.0"
 			}
 		},
 		"node_modules/@nodelib/fs.stat": {
@@ -2155,15 +2164,15 @@
 			}
 		},
 		"node_modules/@nodelib/fs.walk": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-2.0.0.tgz",
+			"integrity": "sha512-54voNDBobGdMl3BUXSu7UaDh1P85PGHWlJ5e0XhPugo1JulOyCtp2I+5ri4wplGDJ8QGwPEQW7/x3yTLU7yF1A==",
 			"dependencies": {
-				"@nodelib/fs.scandir": "2.1.5",
-				"fastq": "^1.6.0"
+				"@nodelib/fs.scandir": "3.0.0",
+				"fastq": "^1.15.0"
 			},
 			"engines": {
-				"node": ">= 8"
+				"node": ">=16.14.0"
 			}
 		},
 		"node_modules/@sinclair/typebox": {
@@ -4148,6 +4157,32 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/eslint/node_modules/@nodelib/fs.scandir": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+			"dev": true,
+			"dependencies": {
+				"@nodelib/fs.stat": "2.0.5",
+				"run-parallel": "^1.1.9"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/eslint/node_modules/@nodelib/fs.walk": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+			"dev": true,
+			"dependencies": {
+				"@nodelib/fs.scandir": "2.1.5",
+				"fastq": "^1.6.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
 		"node_modules/eslint/node_modules/ansi-styles": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -4517,6 +4552,30 @@
 			},
 			"engines": {
 				"node": ">=8.6.0"
+			}
+		},
+		"node_modules/fast-glob/node_modules/@nodelib/fs.scandir": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+			"dependencies": {
+				"@nodelib/fs.stat": "2.0.5",
+				"run-parallel": "^1.1.9"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/fast-glob/node_modules/@nodelib/fs.walk": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+			"dependencies": {
+				"@nodelib/fs.scandir": "2.1.5",
+				"fastq": "^1.6.0"
+			},
+			"engines": {
+				"node": ">= 8"
 			}
 		},
 		"node_modules/fast-glob/node_modules/glob-parent": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 	},
 	"dependencies": {
 		"@babel/parser": "^7.21.4",
+		"@nodelib/fs.walk": "^2.0.0",
 		"bluebird": "^3.7.2",
 		"dotenv": "^16.0.3",
 		"dotenv-expand": "^10.0.0",

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -38,6 +38,7 @@ import { SimpleLogger } from './util/logging/simple-logger.js';
 import { PortAcquisitionClient } from './util/port/port-acquisition-client.js';
 import { PortAcquisitionManager } from './util/port/port-acquisition-manager.js';
 import { getJsonCircularReferenceReplacer } from './util/utils.js';
+import { DefaultCommand } from './workspace.js';
 
 export class Adapter implements TestAdapter, Disposable {
   private readonly logLevel: LogLevel;
@@ -64,7 +65,8 @@ export class Adapter implements TestAdapter, Disposable {
     private readonly projectNamespace: string,
     configStore: ConfigStore<ProjectConfigSetting>,
     portAcquisitionManager: PortAcquisitionManager,
-    projectStatusDisplay: StatusDisplay
+    projectStatusDisplay: StatusDisplay,
+    private readonly defaultCommand: DefaultCommand
   ) {
     this.logLevel = configStore.get<LogLevel>(GeneralConfigSetting.LogLevel);
     this.outputChannelLog = new OutputChannelLog(`${EXTENSION_OUTPUT_CHANNEL_NAME} (${this.projectNamespace})`);
@@ -154,7 +156,8 @@ export class Adapter implements TestAdapter, Disposable {
       this.testRunEmitter as EventEmitter<TestResultEvent>,
       this.retireEmitter,
       this.testServerLog,
-      this.createLogger(MainFactory.name)
+      this.createLogger(MainFactory.name),
+      this.defaultCommand
     );
     testExplorerDisposables.push(factory);
 

--- a/src/core/main-factory.ts
+++ b/src/core/main-factory.ts
@@ -28,6 +28,7 @@ import { PortAcquisitionClient } from '../util/port/port-acquisition-client.js';
 import { ProcessHandler } from '../util/process/process-handler.js';
 import { ProcessLog } from '../util/process/process-log.js';
 import { stripJsComments } from '../util/utils.js';
+import { DefaultCommand } from '../workspace.js';
 import { ProjectType } from './base/project-type.js';
 import { TestDefinitionProvider } from './base/test-definition-provider.js';
 import { TestLoadEvent, TestResultEvent, TestRunEvent } from './base/test-events.js';
@@ -83,7 +84,8 @@ export class MainFactory {
     private readonly testResultEventEmitter: EventEmitter<TestResultEvent>,
     private readonly testRetireEventEmitter: EventEmitter<RetireEvent>,
     private readonly testServerLog: LogAppender,
-    private readonly logger: SimpleLogger
+    private readonly logger: SimpleLogger,
+    private readonly defaultCommand: DefaultCommand
   ) {
     this.disposables.push(logger);
 
@@ -371,7 +373,8 @@ export class MainFactory {
       karmaFactoryConfig,
       this.processHandler,
       serverProcessLog,
-      this.createLogger(KarmaFactory.name)
+      this.createLogger(KarmaFactory.name),
+      this.defaultCommand
     );
   }
 
@@ -400,7 +403,8 @@ export class MainFactory {
       angularFactoryConfig,
       this.processHandler,
       serverProcessLog,
-      this.createLogger(AngularFactory.name)
+      this.createLogger(AngularFactory.name),
+      this.defaultCommand
     );
   }
 

--- a/src/frameworks/angular/angular-factory.ts
+++ b/src/frameworks/angular/angular-factory.ts
@@ -7,6 +7,7 @@ import { SimpleLogger } from '../../util/logging/simple-logger.js';
 import { ProcessHandler } from '../../util/process/process-handler.js';
 import { ProcessLog } from '../../util/process/process-log.js';
 import { excludeSelectedEntries } from '../../util/utils.js';
+import { DefaultCommand } from '../../workspace.js';
 import {
   AngularTestServerExecutor,
   AngularTestServerExecutorOptions
@@ -41,7 +42,8 @@ export class AngularFactory implements Partial<TestFactory> {
     private readonly config: AngularFactoryConfig,
     private readonly processHandler: ProcessHandler,
     private readonly serverProcessLog: ProcessLog,
-    private readonly logger: SimpleLogger
+    private readonly logger: SimpleLogger,
+    private readonly defaultCommand: DefaultCommand
   ) {
     this.disposables.push(this.logger);
   }
@@ -96,7 +98,8 @@ export class AngularFactory implements Partial<TestFactory> {
       this.config.baseKarmaConfFilePath,
       this.processHandler,
       new SimpleLogger(this.logger, AngularTestServerExecutor.name),
-      options
+      options,
+      this.defaultCommand
     );
     this.disposables.push(serverExecutor);
     return serverExecutor;

--- a/src/frameworks/angular/angular-test-server-executor.ts
+++ b/src/frameworks/angular/angular-test-server-executor.ts
@@ -58,7 +58,7 @@ export class AngularTestServerExecutor implements TestServerExecutor {
 
     const runOptions: SimpleProcessOptions = {
       cwd: this.projectPath,
-      shell: false,
+      shell: true,
       env: environment,
       failOnStandardError: this.options.failOnStandardError,
       parentProcessName: AngularTestServerExecutor.name,

--- a/src/frameworks/angular/angular-util.ts
+++ b/src/frameworks/angular/angular-util.ts
@@ -4,8 +4,11 @@ import { join } from 'path';
 import { FileHandler } from '../../util/filesystem/file-handler.js';
 import { Logger } from '../../util/logging/logger.js';
 import { normalizePath } from '../../util/utils.js';
+import { DefaultCommand } from '../../workspace.js';
 import { AngularProjectInfo } from './angular-project-info.js';
 import { AngularWorkspaceInfo } from './angular-workspace-info.js';
+
+const DefaultAngularCommand: DefaultCommand = { package: '@angular/cli', path: ['bin', 'ng'] };
 
 export const getAngularWorkspaceInfo = (
   angularConfigRootPath: string,
@@ -73,7 +76,8 @@ const getAngularJsonWorkspaceInfo = (
   }
   const workspaceInfo: AngularWorkspaceInfo = {
     projects,
-    defaultProject
+    defaultProject,
+    defaultCommand: DefaultAngularCommand
   };
   return workspaceInfo;
 };
@@ -136,7 +140,8 @@ const getAngularCliJsonWorkspaceInfo = (
   }
   const workspaceInfo: AngularWorkspaceInfo = {
     projects,
-    defaultProject
+    defaultProject,
+    defaultCommand: DefaultAngularCommand
   };
   return workspaceInfo;
 };
@@ -187,5 +192,5 @@ const getProjectJsonWorkspaceInfo = (
     return undefined;
   }
 
-  return { projects: projects, defaultProject: undefined };
+  return { projects: projects, defaultProject: undefined, defaultCommand: { package: 'nx', path: ['bin', 'nx'] } };
 };

--- a/src/frameworks/angular/angular-workspace-info.ts
+++ b/src/frameworks/angular/angular-workspace-info.ts
@@ -1,6 +1,8 @@
+import { DefaultCommand } from '../../workspace.js';
 import { AngularProjectInfo } from './angular-project-info.js';
 
 export interface AngularWorkspaceInfo {
   readonly projects: AngularProjectInfo[];
   readonly defaultProject?: AngularProjectInfo;
+  readonly defaultCommand: DefaultCommand;
 }

--- a/src/frameworks/karma/karma-factory.ts
+++ b/src/frameworks/karma/karma-factory.ts
@@ -11,6 +11,7 @@ import { SimpleLogger } from '../../util/logging/simple-logger.js';
 import { ProcessHandler } from '../../util/process/process-handler.js';
 import { ProcessLog } from '../../util/process/process-log.js';
 import { excludeSelectedEntries } from '../../util/utils.js';
+import { DefaultCommand } from '../../workspace.js';
 import { KarmaEnvironmentVariable } from './karma-environment-variable.js';
 import {
   KarmaCommandLineTestRunExecutor,
@@ -54,7 +55,8 @@ export class KarmaFactory implements TestFactory, Disposable {
     private readonly config: KarmaFactoryConfig,
     private readonly processHandler: ProcessHandler,
     private readonly serverProcessLog: ProcessLog,
-    private readonly logger: SimpleLogger
+    private readonly logger: SimpleLogger,
+    private readonly defaultCommand: DefaultCommand
   ) {
     this.disposables.push(this.logger);
   }
@@ -180,7 +182,8 @@ export class KarmaFactory implements TestFactory, Disposable {
       this.config.projectKarmaConfigFilePath,
       this.processHandler,
       this.createLogger(KarmaCommandLineTestServerExecutor.name),
-      options
+      options,
+      this.defaultCommand
     );
     this.disposables.push(testServerExecutor);
     return testServerExecutor;

--- a/src/main.ts
+++ b/src/main.ts
@@ -297,7 +297,7 @@ const processAddedProjects = (
       : [];
 
   projects.forEach(project => {
-    logger.info(() => `Registering project: ${project.projectPath}`);
+    logger.info(() => `Registering project: ${project.shortName}, path: ${project.projectPath}`);
     allWorkspaceProjects.add(project);
 
     const shouldActivateProject = projectPathsToActivate.includes(project.projectPath);

--- a/src/main.ts
+++ b/src/main.ts
@@ -394,7 +394,8 @@ const createProjectAdapter = (
       projectNamespace,
       project.config,
       sharedAdapterComponents.portAcquisitionManager,
-      sharedAdapterComponents.multiStatusDisplay.createDisplay(project.shortName)
+      sharedAdapterComponents.multiStatusDisplay.createDisplay(project.shortName),
+      project.defaultCommand
     );
     testHub.registerTestAdapter(projectAdapter);
 

--- a/src/project-factory.ts
+++ b/src/project-factory.ts
@@ -239,7 +239,8 @@ export class ProjectFactory implements Disposable {
           config: angularChildProjectConfig,
           isPrimary: angularWorkspace.defaultProject
             ? angularChildProjectInfo.name === angularWorkspace.defaultProject.name
-            : false
+            : false,
+          defaultCommand: angularWorkspace.defaultCommand
         };
         workspaceFolderProjects.push(project);
       });
@@ -286,7 +287,8 @@ export class ProjectFactory implements Disposable {
         topLevelProjectPath: absoluteProjectRootPath,
         shortProjectPath: relative(workspaceFolderPath, absoluteProjectRootPath),
         config: projectConfig,
-        isPrimary: true
+        isPrimary: true,
+        defaultCommand: { package: 'karma', path: ['bin', 'karma'] }
       };
       workspaceFolderProjects.push(project);
     }

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -5,6 +5,11 @@ import { ProjectType } from './core/base/project-type.js';
 import { ProjectConfigSetting } from './core/config/config-setting.js';
 import { ConfigStore } from './core/config/config-store.js';
 
+export interface DefaultCommand {
+  package: string;
+  path: string[];
+}
+
 export interface WorkspaceProject {
   readonly shortName: string;
   readonly longName: string;
@@ -18,4 +23,5 @@ export interface WorkspaceProject {
   readonly config: ConfigStore<ProjectConfigSetting>;
   readonly isPrimary: boolean;
   adapter?: Adapter;
+  readonly defaultCommand: DefaultCommand;
 }


### PR DESCRIPTION
Initial NX support. See #79 
No UT added.
No automatic command detection added (Angular Process Command should be set to `npx nx` in settings).
Hardcoded directory names are used as ignore list (`node_modules` and `.*`).

Multi-app test project https://github.com/justdanpo/nx-karma-example
![image](https://github.com/lucono/karma-test-explorer/assets/94048/3fec9aee-2442-49d8-9fb3-58e3c88ac35e)

I'd like to see your comments